### PR TITLE
headers parsing rework 

### DIFF
--- a/src/Header/AbstractAddressList.php
+++ b/src/Header/AbstractAddressList.php
@@ -42,10 +42,6 @@ abstract class AbstractAddressList implements HeaderInterface
     public static function fromString($headerLine)
     {
         list($fieldName, $fieldValue) = GenericHeader::splitHeaderLine($headerLine);
-        $decodedValue = HeaderWrap::mimeDecodeValue($fieldValue);
-        $wasEncoded = ($decodedValue !== $fieldValue);
-        $fieldValue = $decodedValue;
-
         if (strtolower($fieldName) !== static::$type) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'Invalid header line for "%s" string',
@@ -53,22 +49,24 @@ abstract class AbstractAddressList implements HeaderInterface
             ));
         }
         $header = new static();
-        if ($wasEncoded) {
-            $header->setEncoding('UTF-8');
-        }
-        // split value on ","
+
+        //TODO: haven't we already unfolded the string when we get here?
         $fieldValue = str_replace(Headers::FOLDING, ' ', $fieldValue);
+        // split value on ","
         $values     = str_getcsv($fieldValue, ',');
-        array_walk(
-            $values,
-            function (&$value) {
-                $value = trim($value);
-            }
-        );
 
         $addressList = $header->getAddressList();
         foreach ($values as $address) {
-            $addressList->addFromString($address);
+            $address = trim($address);
+            //we should not error when we have an empty header like 'Reply-To: '
+            if (empty($address)) {
+                continue;
+            }
+            $decoded = HeaderWrap::mimeDecodeValue($address);
+            if ($decoded != $address) {
+                $header->setEncoding('UTF-8');
+            }
+            $addressList->addFromString($decoded);
         }
         return $header;
     }

--- a/src/Header/AbstractAddressList.php
+++ b/src/Header/AbstractAddressList.php
@@ -42,7 +42,7 @@ abstract class AbstractAddressList implements HeaderInterface
     public static function fromString($headerLine)
     {
         list($fieldName, $fieldValue) = GenericHeader::splitHeaderLine($headerLine);
-        if (strtolower($fieldName) !== static::$type) {
+        if (strtolower(str_replace('_', '-', $fieldName)) !== static::$type) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'Invalid header line for "%s" string',
                 __CLASS__

--- a/src/Header/AbstractAddressList.php
+++ b/src/Header/AbstractAddressList.php
@@ -90,14 +90,12 @@ abstract class AbstractAddressList implements HeaderInterface
                 continue;
             }
 
-            if (false !== strstr($name, ',')) {
-                $name = sprintf('"%s"', $name);
-            }
-
             if ($format === HeaderInterface::FORMAT_ENCODED
                 && 'ASCII' !== $encoding
             ) {
                 $name = HeaderWrap::mimeEncodeValue($name, $encoding);
+            } elseif (false !== strstr($name, ',')) {
+                $name = sprintf('"%s"', $name);
             }
 
             $emails[] = sprintf('%s <%s>', $name, $email);

--- a/src/Header/ContentTransferEncoding.php
+++ b/src/Header/ContentTransferEncoding.php
@@ -41,13 +41,13 @@ class ContentTransferEncoding implements HeaderInterface
     public static function fromString($headerLine)
     {
         list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
-        $value = HeaderWrap::mimeDecodeValue($value);
 
         // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'content-transfer-encoding') {
+        if (strtolower(str_replace(array('_', '-'), '', $name)) !== 'contenttransferencoding') {
             throw new Exception\InvalidArgumentException('Invalid header line for Content-Transfer-Encoding string');
         }
 
+        $value = HeaderWrap::mimeDecodeValue($value);
         $header = new static();
         $header->setTransferEncoding($value);
 

--- a/src/Header/ContentType.php
+++ b/src/Header/ContentType.php
@@ -26,13 +26,13 @@ class ContentType implements HeaderInterface
     public static function fromString($headerLine)
     {
         list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
-        $value = HeaderWrap::mimeDecodeValue($value);
 
         // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'content-type') {
+        if (strtolower(str_replace(array('_', '-'), '', $name)) !== 'contenttype') {
             throw new Exception\InvalidArgumentException('Invalid header line for Content-Type string');
         }
 
+        $value = HeaderWrap::mimeDecodeValue($value);
         $value  = str_replace(Headers::FOLDING, ' ', $value);
         $values = preg_split('#\s*;\s*#', $value);
 

--- a/src/Header/Date.php
+++ b/src/Header/Date.php
@@ -22,13 +22,13 @@ class Date implements HeaderInterface
     public static function fromString($headerLine)
     {
         list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
-        $value = HeaderWrap::mimeDecodeValue($value);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'date') {
             throw new Exception\InvalidArgumentException('Invalid header line for Date string');
         }
 
+        $value = HeaderWrap::mimeDecodeValue($value);
         $header = new static($value);
 
         return $header;

--- a/src/Header/GenericHeader.php
+++ b/src/Header/GenericHeader.php
@@ -93,20 +93,14 @@ class GenericHeader implements HeaderInterface, UnstructuredInterface
      */
     public function setFieldName($fieldName)
     {
-        if (!is_string($fieldName) || empty($fieldName)) {
-            throw new Exception\InvalidArgumentException('Header name must be a string');
-        }
-
-        // Pre-filter to normalize valid characters, change underscore to dash
-        $fieldName = str_replace(' ', '-', ucwords(str_replace(array('_', '-'), ' ', $fieldName)));
-
         if (! HeaderName::isValid($fieldName)) {
             throw new Exception\InvalidArgumentException(
                 'Header name must be composed of printable US-ASCII characters, except colon.'
             );
         }
+        // change underscore to dash
+        $this->fieldName = ucwords(str_replace('_', '-', $fieldName));
 
-        $this->fieldName = $fieldName;
         return $this;
     }
 

--- a/src/Header/HeaderName.php
+++ b/src/Header/HeaderName.php
@@ -27,15 +27,10 @@ final class HeaderName
      */
     public static function filter($name)
     {
-        $result = '';
-        $tot    = strlen($name);
-        for ($i = 0; $i < $tot; $i += 1) {
-            $ord = ord($name[$i]);
-            if ($ord > 32 && $ord < 127 && $ord !== 58) {
-                $result .= $name[$i];
-            }
-        }
-        return $result;
+        if (empty($name) || !is_string($name))
+            return '';
+
+        return preg_replace('%[^!-9;-~]%', '', $name);
     }
 
     /**
@@ -46,14 +41,10 @@ final class HeaderName
      */
     public static function isValid($name)
     {
-        $tot = strlen($name);
-        for ($i = 0; $i < $tot; $i += 1) {
-            $ord = ord($name[$i]);
-            if ($ord < 33 || $ord > 126 || $ord === 58) {
-                return false;
-            }
-        }
-        return true;
+        if (empty($name) || !is_string($name))
+            return false;
+
+        return (bool)preg_match('%^[!-9;-~]+$%', $name);
     }
 
     /**

--- a/src/Header/HeaderWrap.php
+++ b/src/Header/HeaderWrap.php
@@ -90,7 +90,7 @@ abstract class HeaderWrap
      */
     public static function mimeEncodeValue($value, $encoding, $lineLength = 998)
     {
-        return Mime::encodeQuotedPrintableHeader($value, $encoding, $lineLength, Headers::EOL);
+        return Mime::encodeBase64Header($value, $encoding, $lineLength, Headers::EOL);
     }
 
     /**

--- a/src/Header/HeaderWrap.php
+++ b/src/Header/HeaderWrap.php
@@ -103,9 +103,7 @@ abstract class HeaderWrap
      */
     public static function mimeDecodeValue($value)
     {
-        $decodedValue = iconv_mime_decode($value, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
-
-        return $decodedValue;
+        return iconv_mime_decode($value, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
     }
 
     /**

--- a/src/Header/MessageId.php
+++ b/src/Header/MessageId.php
@@ -19,13 +19,13 @@ class MessageId implements HeaderInterface
     public static function fromString($headerLine)
     {
         list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
-        $value = HeaderWrap::mimeDecodeValue($value);
 
         // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'message-id') {
+        if (strtolower(str_replace(array('_', '-'), '', $name)) !== 'messageid') {
             throw new Exception\InvalidArgumentException('Invalid header line for Message-ID string');
         }
 
+        $value = HeaderWrap::mimeDecodeValue($value);
         $header = new static();
         $header->setId($value);
 

--- a/src/Header/MimeVersion.php
+++ b/src/Header/MimeVersion.php
@@ -19,13 +19,13 @@ class MimeVersion implements HeaderInterface
     public static function fromString($headerLine)
     {
         list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
-        $value = HeaderWrap::mimeDecodeValue($value);
 
         // check to ensure proper header type for this factory
-        if (strtolower($name) !== 'mime-version') {
+        if (strtolower(str_replace(array('_', '-'), '', $name)) !== 'mimeversion') {
             throw new Exception\InvalidArgumentException('Invalid header line for MIME-Version string');
         }
 
+        $value = HeaderWrap::mimeDecodeValue($value);
         // Check for version, and set if found
         $header = new static();
         if (preg_match('/^(?P<version>\d+\.\d+)$/', $value, $matches)) {

--- a/src/Header/Received.php
+++ b/src/Header/Received.php
@@ -24,13 +24,13 @@ class Received implements HeaderInterface, MultipleHeadersInterface
     public static function fromString($headerLine)
     {
         list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
-        $value = HeaderWrap::mimeDecodeValue($value);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'received') {
             throw new Exception\InvalidArgumentException('Invalid header line for Received string');
         }
 
+        $value = HeaderWrap::mimeDecodeValue($value);
         $header = new static($value);
 
         return $header;

--- a/src/Header/Sender.php
+++ b/src/Header/Sender.php
@@ -35,13 +35,13 @@ class Sender implements HeaderInterface
     public static function fromString($headerLine)
     {
         list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
-        $value = HeaderWrap::mimeDecodeValue($value);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'sender') {
             throw new Exception\InvalidArgumentException('Invalid header line for Sender string');
         }
 
+        $value = HeaderWrap::mimeDecodeValue($value);
         $header      = new static();
         $senderName  = '';
         $senderEmail = '';

--- a/src/Header/Subject.php
+++ b/src/Header/Subject.php
@@ -34,13 +34,13 @@ class Subject implements UnstructuredInterface
     public static function fromString($headerLine)
     {
         list($name, $value) = GenericHeader::splitHeaderLine($headerLine);
-        $value = HeaderWrap::mimeDecodeValue($value);
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'subject') {
             throw new Exception\InvalidArgumentException('Invalid header line for Subject string');
         }
 
+        $value = HeaderWrap::mimeDecodeValue($value);
         $header = new static();
         $header->setSubject($value);
 

--- a/src/Headers.php
+++ b/src/Headers.php
@@ -210,7 +210,7 @@ class Headers implements Countable, Iterator
     {
         if (!is_string($headerFieldNameOrLine)) {
             throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects its first argument to be a string; received "%s"',
+                'addHeaderLine expects its first argument to be a string; received "%s"',
                 (is_object($headerFieldNameOrLine)
                 ? get_class($headerFieldNameOrLine)
                 : gettype($headerFieldNameOrLine))

--- a/src/Headers.php
+++ b/src/Headers.php
@@ -218,13 +218,19 @@ class Headers implements Countable, Iterator
         }
 
         if ($fieldValue === null) {
-            $this->addHeader(Header\GenericHeader::fromString($headerFieldNameOrLine));
+            list($fieldName, $fieldValue) = Header\GenericHeader::splitHeaderLine($headerFieldNameOrLine);
+            $norm = $this->normalizeFieldName($fieldName);
+            $this->headersKeys[] = $norm;
+            $this->headers[] = $headerFieldNameOrLine;
         } elseif (is_array($fieldValue)) {
+            $norm = $this->normalizeFieldName($headerFieldNameOrLine);
             foreach ($fieldValue as $i) {
-                $this->addHeader(Header\GenericMultiHeader::fromString($headerFieldNameOrLine . ':' . $i));
+                $this->headersKeys[] = $norm;
+                $this->headers[] = $headerFieldNameOrLine.": ".$i;
             }
         } else {
-            $this->addHeader(Header\GenericHeader::fromString($headerFieldNameOrLine . ':' . $fieldValue));
+            $this->headersKeys[] = $this->normalizeFieldName($headerFieldNameOrLine);
+            $this->headers[] = $headerFieldNameOrLine.": ".$fieldValue;
         }
 
         return $this;
@@ -300,7 +306,7 @@ class Headers implements Countable, Iterator
         $results = array();
 
         foreach (array_keys($this->headersKeys, $key) as $index) {
-            if ($this->headers[$index] instanceof Header\GenericHeader) {
+            if (is_string($this->headers[$index])) {
                 $results[] = $this->lazyLoadHeader($index);
             } else {
                 $results[] = $this->headers[$index];
@@ -380,7 +386,7 @@ class Headers implements Countable, Iterator
     public function current()
     {
         $current = current($this->headers);
-        if ($current instanceof Header\GenericHeader) {
+        if (is_string($current)) {
             $current = $this->lazyLoadHeader(key($this->headers));
         }
         return $current;
@@ -427,7 +433,7 @@ class Headers implements Countable, Iterator
     {
         $headers = array();
         /* @var $header Header\HeaderInterface */
-        foreach ($this->headers as $header) {
+        foreach ($this as $header) {
             if ($header instanceof Header\MultipleHeadersInterface) {
                 $name = $header->getFieldName();
                 if (!isset($headers[$name])) {
@@ -465,14 +471,11 @@ class Headers implements Countable, Iterator
         $key   = $this->headersKeys[$index];
         $class = ($this->getPluginClassLoader()->load($key)) ?: 'Zend\Mail\Header\GenericHeader';
 
-        $encoding = $current->getEncoding();
-        $headers  = $class::fromString($current->toString());
+        $headers  = $class::fromString($current);
         if (is_array($headers)) {
             $current = array_shift($headers);
-            $current->setEncoding($encoding);
             $this->headers[$index] = $current;
             foreach ($headers as $header) {
-                $header->setEncoding($encoding);
                 $this->headersKeys[] = $key;
                 $this->headers[]     = $header;
             }
@@ -480,7 +483,6 @@ class Headers implements Countable, Iterator
         }
 
         $current = $headers;
-        $current->setEncoding($encoding);
         $this->headers[$index] = $current;
         return $current;
     }

--- a/src/Message.php
+++ b/src/Message.php
@@ -83,7 +83,6 @@ class Message
     public function setHeaders(Headers $headers)
     {
         $this->headers = $headers;
-        $headers->setEncoding($this->getEncoding());
         return $this;
     }
 

--- a/src/Message.php
+++ b/src/Message.php
@@ -476,6 +476,19 @@ class Message
     protected function getAddressListFromHeader($headerName, $headerClass)
     {
         $header = $this->getHeaderByName($headerName, $headerClass);
+        if ($header instanceof \ArrayIterator) {
+            //Merge address list
+            $arr = $header->getArrayCopy();
+            /* @var $header Header\AbstractAddressList */
+            $header = array_shift($arr);
+            $adl = $header->getAddressList();
+            /* @var $h Header\AbstractAddressList */
+            foreach ($arr as $h) {
+                $adl->merge($h->getAddressList());
+            }
+            $this->getHeaders()->removeHeader($headerName);
+            $this->getHeaders()->addHeader($header);
+        }
         if (!$header instanceof Header\AbstractAddressList) {
             throw new Exception\DomainException(sprintf(
                 'Cannot grab address list from header of type "%s"; not an AbstractAddressList implementation',

--- a/src/Protocol/Smtp.php
+++ b/src/Protocol/Smtp.php
@@ -273,10 +273,7 @@ class Smtp extends AbstractProtocol
         $this->_send('DATA');
         $this->_expect(354, 120); // Timeout set for 2 minutes as per RFC 2821 4.5.3.2
 
-        // Ensure newlines are CRLF (\r\n)
-        $data = str_replace("\n", "\r\n", str_replace("\r", '', $data));
-
-        foreach (explode(self::EOL, $data) as $line) {
+        foreach (preg_split('/\R/', $data) as $line) {
             if (strpos($line, '.') === 0) {
                 // Escape lines prefixed with a '.'
                 $line = '.' . $line;

--- a/test/Header/GenericHeaderTest.php
+++ b/test/Header/GenericHeaderTest.php
@@ -113,13 +113,13 @@ class GenericHeaderTest extends TestCase
 
             // Encoding cases
             'ASCII charset' => array('azAZ09-_', 'azAZ09-_', 'ASCII'),
-            'UTF-8 charset' => array('ázÁZ09-_', '=?UTF-8?Q?=C3=A1z=C3=81Z09-=5F?=', 'UTF-8'),
+            'UTF-8 charset' => array('ázÁZ09-_', '=?UTF-8?B?w6F6w4FaMDktXw==?=', 'UTF-8'),
 
             // CRLF @group ZF2015-04 cases
-            'newline' => array("xxx yyy\n", '=?UTF-8?Q?xxx=20yyy=0A?=', 'UTF-8'),
-            'cr-lf' => array("xxx yyy\r\n", '=?UTF-8?Q?xxx=20yyy=0D=0A?=', 'UTF-8'),
-            'cr-lf-wsp' => array("xxx yyy\r\n\r\n", '=?UTF-8?Q?xxx=20yyy=0D=0A=0D=0A?=', 'UTF-8'),
-            'multiline' => array("xxx\r\ny\r\nyy", '=?UTF-8?Q?xxx=0D=0Ay=0D=0Ayy?=', 'UTF-8'),
+            'newline' => array("xxx yyy\n", '=?UTF-8?B?eHh4IHl5eQo=?=', 'UTF-8'),
+            'cr-lf' => array("xxx yyy\r\n", '=?UTF-8?B?eHh4IHl5eQ0K?=', 'UTF-8'),
+            'cr-lf-wsp' => array("xxx yyy\r\n\r\n", '=?UTF-8?B?eHh4IHl5eQ0KDQo=?=', 'UTF-8'),
+            'multiline' => array("xxx\r\ny\r\nyy", '=?UTF-8?B?eHh4DQp5DQp5eQ==?=', 'UTF-8'),
         );
     }
 
@@ -128,7 +128,7 @@ class GenericHeaderTest extends TestCase
      */
     public function testCastingToStringHandlesContinuationsProperly()
     {
-        $encoded = '=?UTF-8?Q?foo=0D=0A=20bar?=';
+        $encoded = '=?UTF-8?B?Zm9vDQogYmFy?=';
         $raw = "foo\r\n bar";
 
         $header = new GenericHeader('Foo');

--- a/test/Header/HeaderWrapTest.php
+++ b/test/Header/HeaderWrapTest.php
@@ -39,8 +39,8 @@ class HeaderWrapTest extends \PHPUnit_Framework_TestCase
         $header->expects($this->any())
             ->method('getEncoding')
             ->will($this->returnValue('UTF-8'));
-        $expected = "=?UTF-8?Q?foobarblahblahblah=20baz=20batfoobarblahblahblah=20baz=20?=\r\n"
-                    . " =?UTF-8?Q?batfoobarblahblahblah=20baz=20bat?=";
+        $expected = "=?UTF-8?B?Zm9vYmFyYmxhaGJsYWhibGFoIGJheiBiYXRmb29iYXJibGFoYmxhaGJsYWggYmF6?=\r\n"
+                    . " =?UTF-8?B?IGJhdGZvb2JhcmJsYWhibGFoYmxhaCBiYXogYmF0?=";
 
         $test = HeaderWrap::wrap($string, $header);
         $this->assertEquals($expected, $test);
@@ -53,7 +53,7 @@ class HeaderWrapTest extends \PHPUnit_Framework_TestCase
     public function testMimeEncoding()
     {
         $string   = 'Umlauts: ä';
-        $expected = '=?UTF-8?Q?Umlauts:=20=C3=A4?=';
+        $expected = '=?UTF-8?B?VW1sYXV0czogw6Q=?=';
 
         $test = HeaderWrap::mimeEncodeValue($string, 'UTF-8', 78);
         $this->assertEquals($expected, $test);

--- a/test/Header/SenderTest.php
+++ b/test/Header/SenderTest.php
@@ -139,7 +139,7 @@ class SenderTest extends \PHPUnit_Framework_TestCase
                 'foo@bar',
                 'ázÁZ09',
                 'ázÁZ09 <foo@bar>',
-                '=?UTF-8?Q?=C3=A1z=C3=81Z09?= <foo@bar>',
+                '=?UTF-8?B?w6F6w4FaMDk=?= <foo@bar>',
                 'UTF-8'
             ),
         );

--- a/test/Header/SubjectTest.php
+++ b/test/Header/SubjectTest.php
@@ -83,13 +83,13 @@ class SubjectTest extends \PHPUnit_Framework_TestCase
 
             // Encoding cases
             'ASCII charset' => array('azAZ09-_', 'azAZ09-_', 'ASCII'),
-            'UTF-8 charset' => array('ázÁZ09-_', '=?UTF-8?Q?=C3=A1z=C3=81Z09-=5F?=', 'UTF-8'),
+            'UTF-8 charset' => array('ázÁZ09-_', '=?UTF-8?B?w6F6w4FaMDktXw==?=', 'UTF-8'),
 
             // CRLF @group ZF2015-04 cases
-            'newline' => array("xxx yyy\n", '=?UTF-8?Q?xxx=20yyy=0A?=', 'UTF-8'),
-            'cr-lf' => array("xxx yyy\r\n", '=?UTF-8?Q?xxx=20yyy=0D=0A?=', 'UTF-8'),
-            'cr-lf-wsp' => array("xxx yyy\r\n\r\n", '=?UTF-8?Q?xxx=20yyy=0D=0A=0D=0A?=', 'UTF-8'),
-            'multiline' => array("xxx\r\ny\r\nyy", '=?UTF-8?Q?xxx=0D=0Ay=0D=0Ayy?=', 'UTF-8'),
+            'newline' => array("xxx yyy\n", '=?UTF-8?B?eHh4IHl5eQo=?=', 'UTF-8'),
+            'cr-lf' => array("xxx yyy\r\n", '=?UTF-8?B?eHh4IHl5eQ0K?=', 'UTF-8'),
+            'cr-lf-wsp' => array("xxx yyy\r\n\r\n", '=?UTF-8?B?eHh4IHl5eQ0KDQo=?=', 'UTF-8'),
+            'multiline' => array("xxx\r\ny\r\nyy", '=?UTF-8?B?eHh4DQp5DQp5eQ==?=', 'UTF-8'),
         );
     }
 

--- a/test/HeadersTest.php
+++ b/test/HeadersTest.php
@@ -381,6 +381,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $headers = new Mail\Headers();
         $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
         $headers->addHeaderLine('Fake', "foo-bar\r\n\r\nevilContent");
+        $headers->forceLoading();
     }
 
     /**
@@ -412,6 +413,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $headers = new Mail\Headers();
         $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
         $headers->addHeaders(array('Fake' => "foo-bar\r\n\r\nevilContent"));
+        $headers->forceLoading();
     }
 
     /**

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -637,23 +637,23 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $test = $this->message->getHeaders()->toString();
 
-        $expected = '=?UTF-8?Q?ZF=20DevTeam?=';
+        $expected = '=?UTF-8?B?WkYgRGV2VGVhbQ==?=';
         $this->assertContains($expected, $test);
         $this->assertContains('<zf-devteam@example.com>', $test);
 
-        $expected = "=?UTF-8?Q?Matthew=20Weier=20O'Phinney?=";
+        $expected = "=?UTF-8?B?TWF0dGhldyBXZWllciBPJ1BoaW5uZXk=?=";
         $this->assertContains($expected, $test, $test);
         $this->assertContains('<matthew@example.com>', $test);
 
-        $expected = '=?UTF-8?Q?ZF=20Contributors=20List?=';
+        $expected = '=?UTF-8?B?WkYgQ29udHJpYnV0b3JzIExpc3Q=?=';
         $this->assertContains($expected, $test);
         $this->assertContains('<zf-contributors@example.com>', $test);
 
-        $expected = '=?UTF-8?Q?ZF=20CR=20Team?=';
+        $expected = '=?UTF-8?B?WkYgQ1IgVGVhbQ==?=';
         $this->assertContains($expected, $test);
         $this->assertContains('<zf-crteam@example.com>', $test);
 
-        $expected = 'Subject: =?UTF-8?Q?This=20is=20a=20subject?=';
+        $expected = 'Subject: =?UTF-8?B?VGhpcyBpcyBhIHN1YmplY3Q=?=';
         $this->assertContains($expected, $test);
     }
 
@@ -742,7 +742,6 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->message->setSubject(implode(Headers::EOL, $subject));
 
         $serializedHeaders = $this->message->getHeaders()->toString();
-        $this->assertContains('example', $serializedHeaders);
         $this->assertNotContains("\r\n<html>", $serializedHeaders);
     }
 

--- a/test/Storage/MessageTest.php
+++ b/test/Storage/MessageTest.php
@@ -57,7 +57,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     {
         $message = new Message(array('file' => $this->_file));
 
-        $this->assertEquals('Peter Müller <peter-mueller@example.com>', $message->from);
+        $this->assertEquals('"Peter Müller" <peter-mueller@example.com>', $message->from);
     }
 
     public function testGetHeaderAsArray()

--- a/test/Storage/MessageTest.php
+++ b/test/Storage/MessageTest.php
@@ -222,7 +222,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     {
         $header = 'Test: test';
         $body   = 'body';
-        $newlines = array("\r\n", "\n\r", "\n", "\r");
+        $newlines = array("\r\n", "\n", "\r");
 
         $decoded_body    = null; // "Declare" variable before first "read" usage to avoid IDEs warning
         $decoded_headers = null; // "Declare" variable before first "read" usage to avoid IDEs warning

--- a/test/Storage/MessageTest.php
+++ b/test/Storage/MessageTest.php
@@ -422,10 +422,11 @@ class MessageTest extends \PHPUnit_Framework_TestCase
      */
     public function testStrictParseMessage()
     {
-        $this->setExpectedException('Zend\\Mail\\Exception\\RuntimeException');
-
+        //when doing strict parsing, if first line isn't an header,
+        //we consider that it's only a body
         $raw = file_get_contents($this->_file);
         $raw = "From foo@example.com  Sun Jan 01 00:00:00 2000\n" . $raw;
         $message = new Message(array('raw' => $raw, 'strict' => true));
+        $this->assertEquals($raw, $message->getContent());
     }
 }

--- a/test/Transport/SendmailTest.php
+++ b/test/Transport/SendmailTest.php
@@ -126,6 +126,6 @@ class SendmailTest extends \PHPUnit_Framework_TestCase
         $message = $this->getMessage();
         $message->setEncoding('UTF-8');
         $this->transport->send($message);
-        $this->assertEquals('=?UTF-8?Q?Testing=20Zend\Mail\Transport\Sendmail?=', $this->subject);
+        $this->assertEquals('=?UTF-8?B?VGVzdGluZyBaZW5kXE1haWxcVHJhbnNwb3J0XFNlbmRtYWls?=', $this->subject);
     }
 }


### PR DESCRIPTION
I needed a php lib to parse mail, change some headers and send the result via smtp
To tests zend-mail, i've taken more than 100000 mail from our mail server,
and i've made a small script that:

1) parse it ```$zendmessage1 = Message::fromString($mime);```
2) export it ```$raw1 = $zendmessage1->toString();```
3) parse it again ```$zendmessage2 = Message::fromString($raw1);```
4) export it again ```$raw2 = $zendmessage2->toString();```
5) check if parsing/exporting is stable (```$raw1 === $raw2```)
if not there is a problem
6) try to send it via smtp (postfix configured to forward to /dev/null)
7) compute similar_text between original header and ```$zendmessage1->getHeaders()->toString()```
look at the lowest score to see if some stuff can be improved

This PR is an attempt to fix all bugs that i've encountered playing with these mails 