### PR TITLE
 Header\AbstractAddressList: don't quote and encode 

### DIFF
--- a/src/Header/AbstractAddressList.php
+++ b/src/Header/AbstractAddressList.php
@@ -92,14 +92,12 @@ abstract class AbstractAddressList implements HeaderInterface
                 continue;
             }
 
-            if (false !== strstr($name, ',')) {
-                $name = sprintf('"%s"', $name);
-            }
-
             if ($format === HeaderInterface::FORMAT_ENCODED
                 && 'ASCII' !== $encoding
             ) {
                 $name = HeaderWrap::mimeEncodeValue($name, $encoding);
+            } elseif (false !== strstr($name, ',')) {
+                $name = sprintf('"%s"', $name);
             }
 
             $emails[] = sprintf('%s <%s>', $name, $email);

--- a/src/Headers.php
+++ b/src/Headers.php
@@ -219,7 +219,7 @@ class Headers implements Countable, Iterator
     {
         if (!is_string($headerFieldNameOrLine)) {
             throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects its first argument to be a string; received "%s"',
+                'addHeaderLine expects its first argument to be a string; received "%s"',
                 (is_object($headerFieldNameOrLine)
                 ? get_class($headerFieldNameOrLine)
                 : gettype($headerFieldNameOrLine))


### PR DESCRIPTION
2 simples fixes, a bad sprint call,
and a fix for AddressList
(we quote to escape (ascii) special char (space,comma,>,<, ...),
but if we QP encode, it's redondant)