### PR TITLE
Protocol\Smtp->data(): improve a bit

### DIFF
--- a/src/Protocol/Smtp.php
+++ b/src/Protocol/Smtp.php
@@ -273,11 +273,12 @@ class Smtp extends AbstractProtocol
         $this->_send('DATA');
         $this->_expect(354, 120); // Timeout set for 2 minutes as per RFC 2821 4.5.3.2
 
-        // Ensure newlines are CRLF (\r\n)
-        $data = str_replace("\n", "\r\n", str_replace("\r", '', $data));
+        // Handle CRLF (\r\n) and LF (\n), remove CR (\r)
+        $data = str_replace("\r", '', $data);
+        $data = explode("\n", $data);
 
-        foreach (explode(self::EOL, $data) as $line) {
-            if (strpos($line, '.') === 0) {
+        foreach ($data as $line) {
+            if (isset($line[0]) && $line[0] === '.') {
                 // Escape lines prefixed with a '.'
                 $line = '.' . $line;
             }


### PR DESCRIPTION
replacing \n with \r\n and then calling explode \r\n is useless
also don't use strpos just to check the first char

