### PR TITLE
Protocol\Smtp->data(): be more memory friendly

### DIFF
--- a/src/Protocol/Smtp.php
+++ b/src/Protocol/Smtp.php
@@ -273,16 +273,19 @@ class Smtp extends AbstractProtocol
         $this->_send('DATA');
         $this->_expect(354, 120); // Timeout set for 2 minutes as per RFC 2821 4.5.3.2
 
-        // Ensure newlines are CRLF (\r\n)
-        $data = str_replace("\n", "\r\n", str_replace("\r", '', $data));
 
-        foreach (explode(self::EOL, $data) as $line) {
-            if (strpos($line, '.') === 0) {
+        $line = strtok($data, "\n");
+        while ($line !== false) {
+            $line = rtrim($line, "\r");
+            if (isset($line[0]) && $line[0] === '.') {
                 // Escape lines prefixed with a '.'
                 $line = '.' . $line;
             }
             $this->_send($line);
+            $line = strtok("\n");
         }
+        //release memory
+        strtok('', '');
 
         $this->_send('.');
         $this->_expect(250, 600); // Timeout set for 10 minutes as per RFC 2821 4.5.3.2


### PR DESCRIPTION
With huge mails (50M), i'm hitting memory_limit, so i've done some tests
looking at peak memory usage and average time(10 runs)
- str_replace("\r","") + explode("\n") 250M/0,27s (what we use now)
- preg_split("\r?\n") 200M/1,5s
- strtok("\n") + rtrim("\r") 100M/0,27s
- strpos("\n") + substr() 50M/0,50s

All tests were run with 'php -d"memory_limit=256M" -d"opcache.enable_cli=1"'
I've choose strtok because it's the best balance between time and memory

Before this patch, we were removing \r, now we're keeping them,
in any case \r should be encoded

Signed-off-by: Etienne CHAMPETIER <etienne.champetier@fiducial.net>