### PR TITLE
Protocol\Smtp->data(): be more memory friendly (stream version)

### DIFF
--- a/src/Protocol/Smtp.php
+++ b/src/Protocol/Smtp.php
@@ -273,16 +273,24 @@ class Smtp extends AbstractProtocol
         $this->_send('DATA');
         $this->_expect(354, 120); // Timeout set for 2 minutes as per RFC 2821 4.5.3.2
 
-        // Ensure newlines are CRLF (\r\n)
-        $data = str_replace("\n", "\r\n", str_replace("\r", '', $data));
-
-        foreach (explode(self::EOL, $data) as $line) {
-            if (strpos($line, '.') === 0) {
+        if (($fp = fopen("php://temp", "r+")) === false) {
+            throw new Exception\RuntimeException('cannot fopen');
+        }
+        if (fwrite($fp, $data) === false) {
+            throw new Exception\RuntimeException('cannot fwrite');
+        }
+        unset($data);
+        rewind($fp);
+        //max line length is 998 char + \r\n = 1000
+        while (($line = stream_get_line($fp, 1000, "\n")) !== false) {
+            $line = rtrim($line, "\r");
+            if (isset($line[0]) && $line[0] === '.') {
                 // Escape lines prefixed with a '.'
                 $line = '.' . $line;
             }
             $this->_send($line);
         }
+        fclose($fp);
 
         $this->_send('.');
         $this->_expect(250, 600); // Timeout set for 10 minutes as per RFC 2821 4.5.3.2


### PR DESCRIPTION
The only problem with this version is the dependency on "php://temp"
(not sure if it's enable on all systems, fopen/fwrite can fail)

Before this patch, we were removing \r, now we're keeping them,
in any case \r should be encoded

With huge mails (50M, 660000 lines), i'm hitting memory_limit, so i've done some tests
looking at:
- peak memory usage for big mails (50M, 660000 lines)
- average time(100 runs) for big mails
- average time(1000 runs) for small mails (50k, 1700 lines)

with php5.6/php7

- str_replace("\r","") + explode("\n")
(what we use now)

260M/200M|0,23s/0,08s|0,29ms/0,18ms
```
$data = str_replace("\r", '', $data);
$data = explode("\n", $data);
foreach ($data as $line) {
    if (isset($line[0]) && $line[0] === '.') {
        $line = '.' . $line;
    }
    //send
}
```

- preg_split("\r?\n")

200M/160M|1,5s/0,14s|1,75ms/0,22ms
```
foreach (preg_split('/\r?\n/', $data) as $line) {
    if (isset($line[0]) && $line[0] === '.') {
        $line = '.' . $line;
    }
    //send
}
```

- strpos("\n") + $data[]==="\r" + substr()

50M/50M|0,32s/0,16s|0,86ms/0,41ms
```
$start = 0;
while (($stop = strpos($data, "\n", $start)) !== false) {
    $len = $stop-$start;
    if ($len > 0 && $data[$stop-1] === "\r") {
        $len -= 1;
    }
    $line = substr($data, $start, $len);

    if (isset($line[0]) && $line[0] === '.') {
        $line = '.' . $line;
    }
    //send
    $start = $stop + 1;
}
//last line
$line = substr($data, $start);
if (isset($line[0]) && $line[0] === '.') {
    $line = '.' . $line;
}
//send
```

- str_replace("\r","") + strpos("\n") + substr()

150M/100M|0,28s/0,14s|0,76ms/0,31ms
```
$start = 0;
$data = str_replace("\r", '', $data);
while (($stop = strpos($data, "\n", $start)) !== false) {
    $line = substr($data, $start, $stop-$start);
    if (isset($line[0]) && $line[0] === '.') {
        $line = '.' . $line;
    }
    //send
    $start = $stop + 1;
}
//last line
$line = substr($data, $start);
if (isset($line[0]) && $line[0] === '.') {
    $line = '.' . $line;
}
//send
```

- fwrite(php://temp) + stream_get_line("\n") + rtrim("\r")

50M/50M|0,28s/0,18s|0,68ms/0,40ms
```
$fp = fopen("php://temp", "r+");
fwrite($fp, $data);
unset($data);
rewind($fp);
while (($line = stream_get_line($fp, 1000, "\n")) !== false) {
    $line = rtrim($line, "\r");
    if (isset($line[0]) && $line[0] === '.') {
        $line = '.' . $line;
    }
    //send
}
```

- strtok("\n") + rtrim("\r") (convert multiple \n\n\n in 1 -> ko)

All tests were run with 'php -d"memory_limit=256M" -d"opcache.enable_cli=1"'

Signed-off-by: Etienne CHAMPETIER <etienne.champetier@fiducial.net>