### PR TITLE
Hotfix zendframework/zf2#7555 - Header\Sender::fromString()

### DIFF
--- a/src/Header/Sender.php
+++ b/src/Header/Sender.php
@@ -43,6 +43,12 @@ class Sender implements HeaderInterface
         }
 
         $header     = new static();
+
+        /**
+         * matches the header value so that the email must be enclosed by < > when a name is present
+         * 'name' and 'email' capture groups correspond respectively to 'display-name' and 'addr-spec' in the ABNF
+         * @see https://tools.ietf.org/html/rfc5322#section-3.4
+         */
         $hasMatches = preg_match('/^(?:(?P<name>.+)\s)?(?(name)<|<?)(?P<email>[^\s]+?)(?(name)>|>?)$/', $value, $matches);
 
         if ($hasMatches !== 1) {

--- a/src/Header/Sender.php
+++ b/src/Header/Sender.php
@@ -39,25 +39,23 @@ class Sender implements HeaderInterface
 
         // check to ensure proper header type for this factory
         if (strtolower($name) !== 'sender') {
-            throw new Exception\InvalidArgumentException('Invalid header line for Sender string');
+            throw new Exception\InvalidArgumentException('Invalid header name for Sender string');
         }
 
-        $header      = new static();
-        $senderName  = '';
-        $senderEmail = '';
+        $header     = new static();
+        $hasMatches = preg_match('/^(?:(?P<name>.+)\s)?(?(name)<|<?)(?P<email>[^\s]+?)(?(name)>|>?)$/', $value, $matches);
 
-        // Check for address, and set if found
-        if (preg_match('/^(?P<name>.*?)<(?P<email>[^>]+)>$/', $value, $matches)) {
-            $senderName = trim($matches['name']);
-            if (empty($senderName)) {
-                $senderName = null;
-            }
-            $senderEmail = $matches['email'];
-        } else {
-            $senderEmail = $value;
+        if ($hasMatches !== 1) {
+            throw new Exception\InvalidArgumentException('Invalid header value for Sender string');
         }
 
-        $header->setAddress($senderEmail, $senderName);
+        $senderName = trim($matches['name']);
+
+        if (empty($senderName)) {
+            $senderName = null;
+        }
+
+        $header->setAddress($matches['email'], $senderName);
 
         return $header;
     }

--- a/test/Header/SenderTest.php
+++ b/test/Header/SenderTest.php
@@ -11,6 +11,8 @@ namespace ZendTest\Mail\Header;
 
 use Zend\Mail\Address;
 use Zend\Mail\Header;
+use Zend\Mail\Exception;
+
 
 /**
  * @group      Zend_Mail
@@ -251,8 +253,8 @@ class SenderTest extends \PHPUnit_Framework_TestCase
 
     public function invalidHeaderLinesProvider()
     {
-        $mailInvalidArgumentException = 'Zend\Mail\Exception\InvalidArgumentException';
-        $headerInvalidArgumentException = 'Zend\Mail\Header\Exception\InvalidArgumentException';
+        $mailInvalidArgumentException = Exception\InvalidArgumentException::class;
+        $headerInvalidArgumentException = Header\Exception\InvalidArgumentException::class;
 
         return [
             ['Sender: foo', $mailInvalidArgumentException],


### PR DESCRIPTION
`Header\Sender::fromString()` didn't correctly set the address for some formats (most notably `Sender: email@domain`).

Close zendframework/zf2#7555
Supersede and close #11 