### PR TITLE
Fix mail sender

### DIFF
--- a/src/Header/Sender.php
+++ b/src/Header/Sender.php
@@ -53,6 +53,8 @@ class Sender implements HeaderInterface
                 $senderName = null;
             }
             $senderEmail = $matches['email'];
+        } else {
+            $senderEmail = $value;
         }
 
         $header->setAddress($senderEmail, $senderName);

--- a/test/Header/SenderTest.php
+++ b/test/Header/SenderTest.php
@@ -147,9 +147,16 @@ class SenderTest extends \PHPUnit_Framework_TestCase
 
     public function validSenderHeaderDataProvider()
     {
-        return array_map(function ($parameters) {
+        return array_merge(array_map(function ($parameters) {
             return array_slice($parameters, 2);
-        }, $this->validSenderDataProvider());
+        }, $this->validSenderDataProvider()), [
+            // Per RFC 2822, 3.4 and 3.6.2, "Sender: foo@bar" is valid.
+            'Unbracketed email' => [
+                '<foo@bar>',
+                'foo@bar',
+                'ASCII'
+            ]
+        ]);
     }
 
     public function invalidSenderDataProvider()

--- a/test/Header/SenderTest.php
+++ b/test/Header/SenderTest.php
@@ -31,7 +31,7 @@ class SenderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider validSenderDataProvider
+     * @dataProvider validSenderHeaderDataProvider
      * @group ZF2015-04
      * @param string $email
      * @param null|string $name
@@ -39,7 +39,7 @@ class SenderTest extends \PHPUnit_Framework_TestCase
      * @param string $encodedValue
      * @param string $encoding
      */
-    public function testParseValidSenderHeader($email, $name, $expectedFieldValue, $encodedValue, $encoding)
+    public function testParseValidSenderHeader($expectedFieldValue, $encodedValue, $encoding)
     {
         $header = Header\Sender::fromString('Sender:' . $encodedValue);
 
@@ -143,6 +143,13 @@ class SenderTest extends \PHPUnit_Framework_TestCase
                 'UTF-8'
             ],
         ];
+    }
+
+    public function validSenderHeaderDataProvider()
+    {
+        return array_map(function ($parameters) {
+            return array_slice($parameters, 2);
+        }, $this->validSenderDataProvider());
     }
 
     public function invalidSenderDataProvider()


### PR DESCRIPTION
If I'm not mistaken, in RFC 5322 [3.6.2.](https://tools.ietf.org/html/rfc5322#section-3.6.2) states `sender = "Sender:" mailbox CRLF`, and [3.4.](https://tools.ietf.org/html/rfc5322#section-3.4) `mailbox = name-addr / addr-spec`, where `addr-spec = local-part "@" domain`.
More specifically, I got an email sent from Gmail with `Sender: foo@bar`.
