### PR TITLE
Handle simple comments in address lists

### DIFF
--- a/src/Header/AbstractAddressList.php
+++ b/src/Header/AbstractAddressList.php
@@ -63,6 +63,7 @@ abstract class AbstractAddressList implements HeaderInterface
             $values,
             function (&$value) {
                 $value = trim($value);
+                $value = self::stripComments($value);
             }
         );
 
@@ -154,5 +155,20 @@ abstract class AbstractAddressList implements HeaderInterface
         $name  = $this->getFieldName();
         $value = $this->getFieldValue(HeaderInterface::FORMAT_ENCODED);
         return (empty($value)) ? '' : sprintf('%s: %s', $name, $value);
+    }
+
+    // Supposed to be private, protected as a workaround for PHP bug 68194
+    protected static function stripComments($value)
+    {
+        return preg_replace(
+            '/\\(
+                (
+                    \\\\.|
+                    [^\\\\)]
+                )+
+            \\)/x',
+            '',
+            $value
+        );
     }
 }

--- a/test/Header/AddressListHeaderTest.php
+++ b/test/Header/AddressListHeaderTest.php
@@ -146,6 +146,26 @@ class AddressListHeaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider getHeadersWithComments
+     */
+    public function testDeserializationFromStringWithComments($value)
+    {
+        $header = From::fromString($value);
+        $list = $header->getAddressList();
+        $this->assertEquals(1, count($list));
+        $this->assertTrue($list->has('user@example.com'));
+    }
+
+    public function getHeadersWithComments()
+    {
+        return [
+            ['From: user@example.com (Comment)'],
+            ['From: user@example.com (Comm\\)ent)'],
+            ['From: (Comment\\\\)user@example.com(Another)'],
+        ];
+    }
+
+    /**
      * @group 3789
      * @dataProvider getStringHeadersWithNoWhitespaceSeparator
      */


### PR DESCRIPTION
Handling all comments is a monumental task. The spec [is complicated](https://tools.ietf.org/html/rfc5322#appendix-A.5).
This at least covers a common simple case of comments.
