### PR TITLE
Handle groups in address lists

### DIFF
--- a/src/Header/AbstractAddressList.php
+++ b/src/Header/AbstractAddressList.php
@@ -58,6 +58,7 @@ abstract class AbstractAddressList implements HeaderInterface
         }
         // split value on ","
         $fieldValue = str_replace(Headers::FOLDING, ' ', $fieldValue);
+        $fieldValue = preg_replace('/[^:]+:([^;]*);/', '$1,', $fieldValue);
         $values     = str_getcsv($fieldValue, ',');
         array_walk(
             $values,
@@ -65,6 +66,7 @@ abstract class AbstractAddressList implements HeaderInterface
                 $value = trim($value);
             }
         );
+        $values = array_filter($values);
 
         $addressList = $header->getAddressList();
         foreach ($values as $address) {

--- a/test/Header/AddressListHeaderTest.php
+++ b/test/Header/AddressListHeaderTest.php
@@ -169,4 +169,25 @@ class AddressListHeaderTest extends \PHPUnit_Framework_TestCase
         $address = $list->get('first@last.zend.com');
         $this->assertEquals('Last, First', $address->getName());
     }
+
+    /**
+     * @dataProvider getAddressListsWithGroup
+     */
+    public function testAddressListWithGroup($input, $count, $sample)
+    {
+        $header = To::fromString($input);
+        $list = $header->getAddressList();
+        $this->assertEquals($count, count($list));
+        if ($count > 0) {
+            $this->assertTrue($list->has($sample));
+        }
+    }
+
+    public function getAddressListsWithGroup()
+    {
+        return [
+            ['To: undisclosed-recipients:;', 0, null],
+            ['To: friends: john@example.com; enemies: john@example.net, bart@example.net;', 3, 'john@example.net'],
+        ];
+    }
 }


### PR DESCRIPTION
RFC 5322 [allows](https://tools.ietf.org/html/rfc5322#section-3.4) groups in address lists.
We're not saving the group name and we can't create one, but at least let's parse them.
