### PR TITLE
Use different encoding for ach different Header

### DIFF
--- a/src/Headers.php
+++ b/src/Headers.php
@@ -152,7 +152,7 @@ class Headers implements Countable, Iterator
     {
         $this->encoding = $encoding;
         foreach ($this as $header) {
-            $header->setEncoding($encoding);
+            $header->getEncoding();
         }
         return $this;
     }


### PR DESCRIPTION
This fixes issue #15 and maybe removes the need for pull request #1 
Actually I can't understand the meaning of the attribute "encoding" for Headers ( as collection of Header ). 
Each header can have a different encoding. Header::getEncoding() actually sets the encoding for the header.