### PR TITLE
Fix/add name plus email as string

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -517,6 +517,12 @@ class Message
                 (is_object($emailOrAddressOrList) ? get_class($emailOrAddressOrList) : gettype($emailOrAddressOrList))
             ));
         }
+
+        if (is_string($emailOrAddressOrList) && $name === null) {
+            $addressList->addFromString($emailOrAddressOrList);
+            return;
+        }
+
         $addressList->add($emailOrAddressOrList, $name);
     }
 

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -199,6 +199,16 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('ZF DevTeam', $address->getName());
     }
 
+    public function testCanAddFromAddressUsingEmailAndNameAsString()
+    {
+        $this->message->addFrom('ZF DevTeam <zf-devteam@example.com>');
+        $addresses = $this->message->getFrom();
+        $this->assertEquals(1, count($addresses));
+        $address = $addresses->current();
+        $this->assertEquals('zf-devteam@example.com', $address->getEmail());
+        $this->assertEquals('ZF DevTeam', $address->getName());
+    }
+
     public function testCanAddFromAddressUsingAddressObject()
     {
         $address = new Address('zf-devteam@example.com', 'ZF DevTeam');


### PR DESCRIPTION
Adding addresses as string in the form of 'Name <address@domain.tld>' would throw an exception claiming 'domain.tld>' is an invalid domain...

(Introduced somewhere between 2.4.0 to 2.5.1)

So, this patch tests the $name argument and when omitted calls AddressList::addFromString