### PR TITLE
Fix mail messages with blank line on top

### DIFF
--- a/src/Storage/Message.php
+++ b/src/Storage/Message.php
@@ -42,6 +42,8 @@ class Message extends Part implements Message\MessageInterface
             } else {
                 $params['raw'] = stream_get_contents($params['file']);
             }
+
+            $params['raw'] = ltrim($params['raw']);
         }
 
         if (!empty($params['flags'])) {

--- a/test/Storage/MessageTest.php
+++ b/test/Storage/MessageTest.php
@@ -39,41 +39,19 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->fail('no exception raised while loading unknown file');
     }
 
-    public function testIsMultipart()
+    /**
+     * @dataProvider filesProvider
+     */
+    public function testParseFile($params)
     {
-        $message = new Message(['file' => $this->_file]);
+        $message = new Message($params);
 
-        $this->assertTrue($message->isMultipart());
+        $this->assertTrue($message->isMultipart(), 'isMultipart() value not match');
+        $this->assertEquals($message->subject, 'multipart', 'subject value not match');
+        $this->assertEquals('Peter Müller <peter-mueller@example.com>', $message->from, 'from value not match');
+        $this->assertEquals(['multipart'], $message->getHeader('subject', 'array'), 'getHeader() value not match');
     }
 
-    public function testGetHeader()
-    {
-        $message = new Message(['file' => $this->_file]);
-
-        $this->assertEquals($message->subject, 'multipart');
-    }
-
-    public function testGetDecodedHeader()
-    {
-        $message = new Message(['file' => $this->_file]);
-
-        $this->assertEquals('Peter Müller <peter-mueller@example.com>', $message->from);
-    }
-
-    public function testGetHeaderAsArray()
-    {
-        $message = new Message(['file' => $this->_file]);
-
-        $this->assertEquals($message->getHeader('subject', 'array'), ['multipart']);
-    }
-
-    public function testGetHeaderFromOpenFile()
-    {
-        $fh = fopen($this->_file, 'r');
-        $message = new Message(['file' => $fh]);
-
-        $this->assertEquals($message->subject, 'multipart');
-    }
 
     public function testGetFirstPart()
     {
@@ -427,5 +405,17 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $raw = file_get_contents($this->_file);
         $raw = "From foo@example.com  Sun Jan 01 00:00:00 2000\n" . $raw;
         $message = new Message(['raw' => $raw, 'strict' => true]);
+    }
+
+    public function filesProvider()
+    {
+        $filePath = __DIR__ . '/../_files/mail.txt';
+
+        return [
+            // Description => [params]
+            'resource' => [['file' => fopen($filePath, 'r')]],
+            'file path' => [['file' => $filePath]],
+            'raw' => [['raw' => file_get_contents($filePath)]],
+        ];
     }
 }

--- a/test/Storage/MessageTest.php
+++ b/test/Storage/MessageTest.php
@@ -410,12 +410,14 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     public function filesProvider()
     {
         $filePath = __DIR__ . '/../_files/mail.txt';
+        $fileBlankLineOnTop = __DIR__ . '/../_files/mail_blank_top_line.txt';
 
         return [
             // Description => [params]
             'resource' => [['file' => fopen($filePath, 'r')]],
             'file path' => [['file' => $filePath]],
             'raw' => [['raw' => file_get_contents($filePath)]],
+            'file with blank line on top' => [['file' => $fileBlankLineOnTop]],
         ];
     }
 }

--- a/test/_files/mail_blank_top_line.txt
+++ b/test/_files/mail_blank_top_line.txt
@@ -1,0 +1,28 @@
+
+To: foo@example.com
+Subject: multipart
+Date: Sun, 01 Jan 2000 00:00:00 +0000
+From: =?UTF-8?Q?"Peter M=C3=BCller"?= <peter-mueller@example.com>
+ContENT-type: multipart/alternative; boUNDary="crazy-multipart"
+Message-ID: <CALTvGe4_oYgf9WsYgauv7qXh2-6=KbPLExmJNG7fCs9B=1nOYg@mail.example.com>
+MIME-version: 1.0
+
+multipart message
+--crazy-multipart
+Content-type: text/plain
+
+The first part 
+is horizontal
+
+--crazy-multipart
+Content-type: text/x-vertical
+
+T s p i v
+h e a s e
+e c r   r
+  o t   t
+  n     i
+  d     c
+        a
+        l
+--crazy-multipart--


### PR DESCRIPTION
At the moment of write this patch GMail (a popular mail provider) prepend mail messages with a line with whitespaces

![image](https://cloud.githubusercontent.com/assets/1301698/9739630/fc2a4c40-5650-11e5-9848-ef3fac0aeccf.png)

This PR remove that line before parse.