### PR TITLE
Make return types more close to the real behavior

### DIFF
--- a/src/Header/ContentTransferEncoding.php
+++ b/src/Header/ContentTransferEncoding.php
@@ -85,7 +85,7 @@ class ContentTransferEncoding implements HeaderInterface
      *
      * @param  string $transferEncoding
      * @throws Exception\InvalidArgumentException
-     * @return self
+     * @return $this
      */
     public function setTransferEncoding($transferEncoding)
     {

--- a/src/Header/HeaderInterface.php
+++ b/src/Header/HeaderInterface.php
@@ -29,7 +29,7 @@ interface HeaderInterface
      * Factory to generate a header object from a string
      *
      * @param string $headerLine
-     * @return self
+     * @return static
      * @throws Exception\InvalidArgumentException If the header does not match with RFC 2822 definition.
      * @see http://tools.ietf.org/html/rfc2822#section-2.2
      */
@@ -54,7 +54,7 @@ interface HeaderInterface
      * Set header encoding
      *
      * @param  string $encoding
-     * @return self
+     * @return $this
      */
     public function setEncoding($encoding);
 


### PR DESCRIPTION
$this it's better for fluent interfaces and mutable objects.
static is the correct for static constructors.