### PR TITLE
Allow to handle reuse time limit

### DIFF
--- a/src/Protocol/AbstractProtocol.php
+++ b/src/Protocol/AbstractProtocol.php
@@ -59,6 +59,12 @@ abstract class AbstractProtocol
     protected $socket;
 
     /**
+     * Socket connection start time
+     * @var int
+     */
+    protected $startTime;
+
+    /**
      * Last request sent to server
      * @var string
      */
@@ -131,6 +137,16 @@ abstract class AbstractProtocol
      * Concrete adapters for this class will implement their own unique connect scripts, using the _connect() method to create the socket resource.
      */
     abstract public function connect();
+
+    /**
+     * Retrieve the time the socket has started
+     *
+     * @return string
+     */
+    public function getStartTime()
+    {
+        return $this->startTime;
+    }
 
     /**
      * Retrieve the last client request
@@ -213,7 +229,18 @@ abstract class AbstractProtocol
             throw new Exception\RuntimeException('Could not set stream timeout');
         }
 
+        $this->_startTime();
+
         return $result;
+    }
+
+    /**
+     * Mark the socket connection start time
+     *
+     */
+    protected function _startTime()
+    {
+        $this->startTime = time();
     }
 
     /**
@@ -225,6 +252,8 @@ abstract class AbstractProtocol
         if (is_resource($this->socket)) {
             fclose($this->socket);
         }
+
+        $this->startTime = null;
     }
 
     /**

--- a/src/Protocol/Smtp.php
+++ b/src/Protocol/Smtp.php
@@ -344,13 +344,18 @@ class Smtp extends AbstractProtocol
     /**
      * Issues the QUIT command and clears the current session
      *
+     * @param  bool $completeQuit Whether or not do a complete QUIT or ignore possible errors like reuse timeout
      */
-    public function quit()
+    public function quit($completeQuit = true)
     {
         if ($this->sess) {
             $this->auth = false;
-            $this->_send('QUIT');
-            $this->_expect(221, 300); // Timeout set for 5 minutes as per RFC 2821 4.5.3.2
+
+            if ($completeQuit) {
+                $this->_send('QUIT');
+                $this->_expect(221, 300); // Timeout set for 5 minutes as per RFC 2821 4.5.3.2
+            }
+
             $this->_stopSession();
         }
     }

--- a/src/Transport/Smtp.php
+++ b/src/Transport/Smtp.php
@@ -224,6 +224,17 @@ class Smtp implements TransportInterface
     {
         // If sending multiple messages per session use existing adapter
         $connection = $this->getConnection();
+        $options = $this->getOptions();
+        $reuseTimeLimit = $options->getReuseTimeLimit();
+
+        if (($connection instanceof Protocol\Smtp)
+            && $reuseTimeLimit >= 0
+            && $connection->getStartTime()
+            && ((time() - $connection->getStartTime()) >= $reuseTimeLimit)
+        ) {
+            $connection->quit(false);
+            $connection->disconnect();
+        }
 
         if (!($connection instanceof Protocol\Smtp) || !$connection->hasSession()) {
             $connection = $this->connect();

--- a/src/Transport/SmtpOptions.php
+++ b/src/Transport/SmtpOptions.php
@@ -42,6 +42,11 @@ class SmtpOptions extends AbstractOptions
     protected $port = 25;
 
     /**
+     * @var int
+     */
+    protected $reuseTimeLimit = -1;
+
+    /**
      * Return the local client hostname
      *
      * @return string
@@ -176,6 +181,36 @@ class SmtpOptions extends AbstractOptions
             ));
         }
         $this->port = $port;
+        return $this;
+    }
+
+    /**
+     * Get the reuse time limit the SMTP server has
+     *
+     * @return int
+     */
+    public function getReuseTimeLimit()
+    {
+        return $this->reuseTimeLimit;
+    }
+
+    /**
+     * Set the reuse time limit the SMTP server has
+     *
+     * @param  int $reuseTimeLimit
+     * @throws \Zend\Mail\Exception\InvalidArgumentException
+     * @return SmtpOptions
+     */
+    public function setReuseTimeLimit($reuseTimeLimit)
+    {
+        $reuseTimeLimit = (int) $reuseTimeLimit;
+        if ($reuseTimeLimit < -1) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Reuse time limit must be greater than or equal to -1; received "%d"',
+                $reuseTimeLimit
+            ));
+        }
+        $this->reuseTimeLimit = $reuseTimeLimit;
         return $this;
     }
 }

--- a/test/Protocol/SmtpTest.php
+++ b/test/Protocol/SmtpTest.php
@@ -101,4 +101,14 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
         $this->connection->disconnect();
         $this->assertFalse($this->connection->getAuth());
     }
+
+    public function testStartTime()
+    {
+        $yesterday = (time() - 86400);
+        $this->assertNull($this->connection->getStartTime());
+        $this->connection->connect();
+        $this->assertGreaterThan($yesterday, $this->connection->getStartTime());
+        $this->connection->disconnect();
+        $this->assertNull($this->connection->getStartTime());
+    }
 }

--- a/test/Transport/SmtpTest.php
+++ b/test/Transport/SmtpTest.php
@@ -239,6 +239,9 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->connection->hasSession());
     }
 
+    /*
+     * @see https://github.com/zendframework/zend-mail/pull/27
+     */
     public function testHandleReuseTimeLimit()
     {
         $message = $this->getMessage();


### PR DESCRIPTION
Some SMTP server like postfix have a reuse time limit:
http://www.postfix.org/postconf.5.html#smtp_connection_reuse_time_limit

After this time, which is non-infinite by default in postfix, **any** command sent will raise a `4.4.2 *host* Error: timeout exceeded` [Exception](https://github.com/zendframework/zend-mail/blob/release-2.5.2/src/Protocol/AbstractProtocol.php#L327), [`QUIT`](https://github.com/zendframework/zend-mail/blob/release-2.5.2/src/Protocol/Smtp.php#L352) and [`RSET`](https://github.com/zendframework/zend-mail/blob/release-2.5.2/src/Protocol/Smtp.php#L310) too.

The only way to keep using the same smtp object instance, is to force the session end by quitting without QUIT message, and `fclose` the stream resource, to immediately reopen it. This is the use case:
```php
$transport = new Smtp();
$transport->send(new Message());

// A long running script, likely a server-side only tool script
sleep(600);

$transport->send(new Message());
```
Since we do not have an internal transport timer between the two calls, we need to track the time spent saving the connect start time, and checking it in the second send call.

By default, the reuse time limit I set is `-1` which corresponds to infinite and mantain backward compatibility.
`0` can be set to restart the connection on every message.
To tackle the postfix configuration, `270` seconds are enough.

As soon as you accept and merge the PR, I'm going to PR against https://github.com/zendframework/zf2-documentation with explanation on why and how.