### PR TITLE
Fix HeaderValue throwing an exception on legal characters

### DIFF
--- a/src/Header/HeaderValue.php
+++ b/src/Header/HeaderValue.php
@@ -28,20 +28,18 @@ final class HeaderValue
     public static function filter($value)
     {
         $result = '';
-        $tot    = strlen($value);
+        $total  = strlen($value);
 
         // Filter for CR and LF characters, leaving CRLF + WSP sequences for
         // Long Header Fields (section 2.2.3 of RFC 2822)
-        for ($i = 0; $i < $tot; $i += 1) {
+        for ($i = 0; $i < $total; $i += 1) {
             $ord = ord($value[$i]);
-            if (($ord < 32 || $ord > 126)
-                && $ord !== 13
-            ) {
+            if ($ord === 10 || $ord > 126) {
                 continue;
             }
 
             if ($ord === 13) {
-                if ($i + 2 >= $tot) {
+                if ($i + 2 >= $total) {
                     continue;
                 }
 
@@ -72,17 +70,17 @@ final class HeaderValue
      */
     public static function isValid($value)
     {
-        $tot = strlen($value);
-        for ($i = 0; $i < $tot; $i += 1) {
+        $total = strlen($value);
+        for ($i = 0; $i < $total; $i += 1) {
             $ord = ord($value[$i]);
-            if (($ord < 32 || $ord > 126)
-                && $ord !== 13
-            ) {
+
+            // bare LF means we aren't valid
+            if ($ord === 10 || $ord > 126) {
                 return false;
             }
 
             if ($ord === 13) {
-                if ($i + 2 >= $tot) {
+                if ($i + 2 >= $total) {
                     return false;
                 }
 
@@ -93,6 +91,7 @@ final class HeaderValue
                     return false;
                 }
 
+                // skip over the LF following this
                 $i += 2;
             }
         }

--- a/test/Header/HeaderValueTest.php
+++ b/test/Header/HeaderValueTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Mail\Header;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionClass;
 use Zend\Mail\Header\HeaderValue;
 
 class HeaderValueTest extends TestCase
@@ -30,7 +31,8 @@ class HeaderValueTest extends TestCase
             ["This is a\r\r test", "This is a test"],
             ["This is a \r\r\n test", "This is a \r\n test"],
             ["This is a \r\n\r\ntest", "This is a test"],
-            ["This is a \r\n\n\r\n test", "This is a \r\n test"]
+            ["This is a \r\n\n\r\n test", "This is a \r\n test"],
+            ["This is a test\r\n", "This is a test"],
         ];
     }
 
@@ -56,7 +58,11 @@ class HeaderValueTest extends TestCase
             ["This is a\r\r test", 'assertFalse'],
             ["This is a \r\r\n test", 'assertFalse'],
             ["This is a \r\n\r\ntest", 'assertFalse'],
-            ["This is a \r\n\n\r\n test", 'assertFalse']
+            ["This is a \r\n\n\r\n test", 'assertFalse'],
+            ["This\tis\ta test", 'assertTrue'],
+            ["This is\ta \r\n test", 'assertTrue'],
+            ["This\tis\ta\ntest", 'assertFalse'],
+            ["This is a \r\t\n \r\n test", 'assertFalse'],
         ];
     }
 
@@ -81,7 +87,7 @@ class HeaderValueTest extends TestCase
             ["This is a\r\r test"],
             ["This is a \r\r\n test"],
             ["This is a \r\n\r\ntest"],
-            ["This is a \r\n\n\r\n test"]
+            ["This is a \r\n\n\r\n test"],
         ];
     }
 
@@ -93,5 +99,11 @@ class HeaderValueTest extends TestCase
     {
         $this->setExpectedException('Zend\Mail\Header\Exception\RuntimeException', 'Invalid');
         HeaderValue::assertValid($value);
+    }
+
+    public function testCannotBeConstructed()
+    {
+        $class = new ReflectionClass('Zend\Mail\Header\HeaderValue');
+        $this->assertFalse($class->isInstantiable());
     }
 }


### PR DESCRIPTION
In RFC 2822, section 2.2, there are different conditions used for header names vs header values.

Header names are restricted to only printable ascii characters (with folding allowed), while header values are allowed any us-ascii character (and `"\r\n "`) except a bare LF or CR.

This is a major problem, because Apache and Outlook/Office365 use tab characters to fold their subject lines. These characters are perfectly valid according to the RFC, yet throw an exception when read.

Relevant spec is below (Section 3.2.1):

```
NO-WS-CTL       =       %d1-8 /         ; US-ASCII control characters
                        %d11 /          ;  that do not include the
                        %d12 /          ;  carriage return, line feed,
                        %d14-31 /       ;  and white space characters
                        %d127

text            =       %d1-9 /         ; Characters excluding CR and LF
                        %d11 /
                        %d12 /
                        %d14-127 /
                        obs-text

specials        =       "(" / ")" /     ; Special characters used in
                        "<" / ">" /     ;  other parts of the syntax
                        "[" / "]" /
                        ":" / ";" /
                        "@" / "\" /
                        "," / "." /
                        DQUOTE

   No special semantics are attached to these tokens.  They are simply
   single characters.
```

Header names are `NO-WS-CTL - specials`, while header values are text with folding allowed.