### PR TITLE
Zend\Mail\Transport\SendMail throws wrong exceptions.

### DIFF
--- a/src/Transport/Sendmail.php
+++ b/src/Transport/Sendmail.php
@@ -12,7 +12,7 @@ namespace Zend\Mail\Transport;
 use Traversable;
 use Zend\Mail;
 use Zend\Mail\Address\AddressInterface;
-use Zend\Mail\Exception;
+use Zend\Mail\Transport\Exception;
 use Zend\Mail\Header\HeaderInterface;
 
 /**
@@ -64,7 +64,7 @@ class Sendmail implements TransportInterface
      * Used to populate the additional_parameters argument to mail()
      *
      * @param  null|string|array|Traversable $parameters
-     * @throws \Zend\Mail\Exception\InvalidArgumentException
+     * @throws \Zend\Mail\Transport\Exception\InvalidArgumentException
      * @return Sendmail
      */
     public function setParameters($parameters)
@@ -98,7 +98,7 @@ class Sendmail implements TransportInterface
      * Primarily for testing purposes, but could be used to curry arguments.
      *
      * @param  callable $callable
-     * @throws \Zend\Mail\Exception\InvalidArgumentException
+     * @throws \Zend\Mail\Transport\Exception\InvalidArgumentException
      * @return Sendmail
      */
     public function setCallable($callable)
@@ -143,7 +143,7 @@ class Sendmail implements TransportInterface
      * Prepare recipients list
      *
      * @param  \Zend\Mail\Message $message
-     * @throws \Zend\Mail\Exception\RuntimeException
+     * @throws \Zend\Mail\Transport\Exception\RuntimeException
      * @return string
      */
     protected function prepareRecipients(Mail\Message $message)
@@ -271,7 +271,7 @@ class Sendmail implements TransportInterface
      * @param  string $message
      * @param  string $headers
      * @param  $parameters
-     * @throws \Zend\Mail\Exception\RuntimeException
+     * @throws \Zend\Mail\Transport\Exception\RuntimeException
      */
     public function mailHandler($to, $subject, $message, $headers, $parameters)
     {

--- a/src/Transport/Sendmail.php
+++ b/src/Transport/Sendmail.php
@@ -12,7 +12,6 @@ namespace Zend\Mail\Transport;
 use Traversable;
 use Zend\Mail;
 use Zend\Mail\Address\AddressInterface;
-use Zend\Mail\Transport\Exception;
 use Zend\Mail\Header\HeaderInterface;
 
 /**


### PR DESCRIPTION
Fix wrong namespace.

Fix https://github.com/zendframework/zf2/issues/7639