### PR TITLE
Check that $token[0] exists before trying to use it.

### DIFF
--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -183,6 +183,9 @@ class Imap
         $line = rtrim($line) . ' ';
         while (($pos = strpos($line, ' ')) !== false) {
             $token = substr($line, 0, $pos);
+            if (!strlen($token)) {
+                continue;
+            }
             while ($token[0] == '(') {
                 array_push($stack, $tokens);
                 $tokens = [];


### PR DESCRIPTION
With Courier IMAP, you will get an error when checking for $token[0] for some responses, so we ensure that it exists first.