### PR TITLE
Removed the zend-servicemanager usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,14 @@
     },
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-crypt": "~2.5",
+        "zendframework/zend-crypt": "dev-develop as 2.6.0",
         "zendframework/zend-loader": "~2.5",
         "zendframework/zend-mime": "~2.5",
-        "zendframework/zend-stdlib": "~2.5",
+        "zendframework/zend-stdlib": "~2.7",
         "zendframework/zend-validator": "~2.5"
     },
     "require-dev": {
         "zendframework/zend-config": "~2.5",
-        "zendframework/zend-servicemanager": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,12 @@
     },
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-crypt": "dev-develop as 2.6.0",
+        "zendframework/zend-crypt": "^2.5 || ^3.0",
         "zendframework/zend-loader": "~2.5",
         "zendframework/zend-mime": "~2.5",
         "zendframework/zend-stdlib": "~2.7",
-        "zendframework/zend-validator": "~2.5"
+        "zendframework/zend-validator": "~2.5",
+        "container-interop/container-interop": "^1.1"
     },
     "require-dev": {
         "zendframework/zend-config": "~2.5",

--- a/src/Protocol/SmtpPluginManager.php
+++ b/src/Protocol/SmtpPluginManager.php
@@ -9,13 +9,15 @@
 
 namespace Zend\Mail\Protocol;
 
+use Interop\Container\ContainerInterface;
+
 /**
  * Plugin manager implementation for SMTP extensions.
  *
  * Enforces that SMTP extensions retrieved are instances of Smtp. Additionally,
  * it registers a number of default extensions available.
  */
-class SmtpPluginManager
+class SmtpPluginManager implements ContainerInterface
 {
     /**
      * Default set of plugins

--- a/src/Protocol/SmtpPluginManager.php
+++ b/src/Protocol/SmtpPluginManager.php
@@ -9,22 +9,20 @@
 
 namespace Zend\Mail\Protocol;
 
-use Zend\ServiceManager\AbstractPluginManager;
-
 /**
  * Plugin manager implementation for SMTP extensions.
  *
  * Enforces that SMTP extensions retrieved are instances of Smtp. Additionally,
  * it registers a number of default extensions available.
  */
-class SmtpPluginManager extends AbstractPluginManager
+class SmtpPluginManager
 {
     /**
-     * Default set of extensions
+     * Default set of plugins
      *
      * @var array
      */
-    protected $invokableClasses = [
+    protected $plugins = [
         'crammd5' => 'Zend\Mail\Protocol\Smtp\Auth\Crammd5',
         'login'   => 'Zend\Mail\Protocol\Smtp\Auth\Login',
         'plain'   => 'Zend\Mail\Protocol\Smtp\Auth\Plain',
@@ -32,25 +30,25 @@ class SmtpPluginManager extends AbstractPluginManager
     ];
 
     /**
-     * Validate the plugin
+     * Do we have the plugin?
      *
-     * Checks that the extension loaded is an instance of Smtp.
-     *
-     * @param  mixed $plugin
-     * @return void
-     * @throws Exception\InvalidArgumentException if invalid
+     * @param  string $id
+     * @return bool
      */
-    public function validatePlugin($plugin)
+    public function has($id)
     {
-        if ($plugin instanceof Smtp) {
-            // we're okay
-            return;
-        }
-
-        throw new Exception\InvalidArgumentException(sprintf(
-            'Plugin of type %s is invalid; must extend %s\Smtp',
-            (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
-            __NAMESPACE__
-        ));
+        return array_key_exists($id, $this->plugins);
+    }
+    /**
+     * Retrieve the smtp plugin
+     *
+     * @param  string $id
+     * @param  array $options
+     * @return AbstractProtocol
+     */
+    public function get($id, array $options = null)
+    {
+        $class = $this->plugins[$id];
+        return new $class($options);
     }
 }


### PR DESCRIPTION
This PR removes the usage of zend-servicemanager using a custom SmtpPluginManager. This removal simplify the usage of the component.