### PR TITLE
Fix space typo in exception message

### DIFF
--- a/src/Headers.php
+++ b/src/Headers.php
@@ -107,7 +107,7 @@ class Headers implements Countable, Iterator
 
             // Line does not match header format!
             throw new Exception\RuntimeException(sprintf(
-                'Line "%s"does not match header format!',
+                'Line "%s" does not match header format!',
                 $line
             ));
         }


### PR DESCRIPTION
Just added missing space to exception message