### PR TITLE
Remove zend-servicemanager dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     },
     "require-dev": {
         "zendframework/zend-config": "~2.5",
-        "zendframework/zend-servicemanager": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },


### PR DESCRIPTION
Looks like `zend-servicemanager` is not required by this component - I can't find any references in the code, and tests are not failing without it.