### PR TITLE
ServiceManager v3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "zendframework/zend-config": "~2.5",
-        "zendframework/zend-servicemanager": "~2.5",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/src/Protocol/SmtpPluginManager.php
+++ b/src/Protocol/SmtpPluginManager.php
@@ -10,6 +10,8 @@
 namespace Zend\Mail\Protocol;
 
 use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception\InvalidServiceException;
+use Zend\ServiceManager\Factory\InvokableFactory;
 
 /**
  * Plugin manager implementation for SMTP extensions.
@@ -20,37 +22,73 @@ use Zend\ServiceManager\AbstractPluginManager;
 class SmtpPluginManager extends AbstractPluginManager
 {
     /**
+     * @var string
+     */
+    protected $instanceOf = Smtp::class;
+
+    /**
      * Default set of extensions
      *
      * @var array
      */
-    protected $invokableClasses = [
-        'crammd5' => 'Zend\Mail\Protocol\Smtp\Auth\Crammd5',
-        'login'   => 'Zend\Mail\Protocol\Smtp\Auth\Login',
-        'plain'   => 'Zend\Mail\Protocol\Smtp\Auth\Plain',
-        'smtp'    => 'Zend\Mail\Protocol\Smtp',
+    protected $aliases = [
+        'crammd5' => Smtp\Auth\Crammd5::class,
+        'Crammd5' => Smtp\Auth\Crammd5::class,
+        'login'   => Smtp\Auth\Login::class,
+        'Login'   => Smtp\Auth\Login::class,
+        'plain'   => Smtp\Auth\Plain::class,
+        'Plain'   => Smtp\Auth\Plain::class,
+        'smtp'    => Smtp::class,
+        'Smtp'    => Smtp::class,
+    ];
+
+    protected $factories = [
+        Smtp\Auth\Crammd5::class          => InvokableFactory::class,
+        'zendmailprotocolsmtpauthcrammd5' => InvokableFactory::class,
+        Smtp\Auth\Login::class            => InvokableFactory::class,
+        'zendmailprotocolsmtpauthlogin'   => InvokableFactory::class,
+        Smtp\Auth\Plain::class            => InvokableFactory::class,
+        'zendmailprotocolsmtpauthplain'   => InvokableFactory::class,
+        Smtp::class                       => InvokableFactory::class,
+        'zendmailprotocolsmtp'            => InvokableFactory::class,
     ];
 
     /**
-     * Validate the plugin
+     * Validate the plugin is of the expected type (v3).
      *
-     * Checks that the extension loaded is an instance of Smtp.
+     * Validates against `$instanceOf`.
      *
-     * @param  mixed $plugin
-     * @return void
-     * @throws Exception\InvalidArgumentException if invalid
+     * @param mixed $instance
+     * @throws InvalidServiceException
      */
-    public function validatePlugin($plugin)
+    public function validate($instance)
     {
-        if ($plugin instanceof Smtp) {
-            // we're okay
-            return;
+        if (!$instance instanceof $this->instanceOf) {
+            throw new InvalidServiceException(
+                sprintf(
+                    '%s can only create instances of %s; %s is invalid',
+                    get_class($this),
+                    $this->instanceOf,
+                    (is_object($instance) ? get_class($instance) : gettype($instance))
+                )
+            );
         }
+    }
 
-        throw new Exception\InvalidArgumentException(sprintf(
-            'Plugin of type %s is invalid; must extend %s\Smtp',
-            (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
-            __NAMESPACE__
-        ));
+    /**
+     * Validate the plugin is of the expected type (v2).
+     *
+     * Proxies to `validate()`.
+     *
+     * @param mixed $instance
+     * @throws Exception\InvalidArgumentException
+     */
+    public function validatePlugin($instance)
+    {
+        try {
+            $this->validate($instance);
+        } catch (InvalidServiceException $e) {
+            throw new Exception\InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        }
     }
 }

--- a/src/Transport/Smtp.php
+++ b/src/Transport/Smtp.php
@@ -14,6 +14,7 @@ use Zend\Mail\Headers;
 use Zend\Mail\Message;
 use Zend\Mail\Protocol;
 use Zend\Mail\Protocol\Exception as ProtocolException;
+use Zend\ServiceManager\ServiceManager;
 
 /**
  * SMTP connection object
@@ -123,7 +124,7 @@ class Smtp implements TransportInterface
     public function getPluginManager()
     {
         if (null === $this->plugins) {
-            $this->setPluginManager(new Protocol\SmtpPluginManager());
+            $this->setPluginManager(new Protocol\SmtpPluginManager(new ServiceManager()));
         }
         return $this->plugins;
     }

--- a/test/Protocol/SmtpPluginManagerCompatibilityTest.php
+++ b/test/Protocol/SmtpPluginManagerCompatibilityTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ZendTest\Mail\Protocol;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Mail\Exception\InvalidArgumentException;
+use Zend\Mail\Protocol\Smtp;
+use Zend\Mail\Protocol\SmtpPluginManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+
+class PluginManagerCompatibilityTest extends TestCase
+{
+    use CommonPluginManagerTrait;
+
+    protected function getPluginManager()
+    {
+        return new SmtpPluginManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return InvalidArgumentException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        return Smtp::class;
+    }
+}


### PR DESCRIPTION
1. Updated composer dependencies
2. Updated SmtpPluginManager according to https://github.com/zendframework/maintainers/wiki/ZF3-ServiceManager-component-refactors,-phase-2:
  * removed invokables
  * added aliases
  * added factories
  * added v3-compatible `validate()` method
  * update `validatePlugin` to proxy to `validate`
3. Added `PluginManagerCompatibilityTest`
4. Updated `Zend\Mail\Transport\Smtp::getPluginManager()` to inject empty `ServiceManager`, as it is required by AbstractPluginManager constructor.