### PR TITLE
make zend-crypt optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     },
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-crypt": "~2.5",
         "zendframework/zend-loader": "~2.5",
         "zendframework/zend-mime": "~2.5",
         "zendframework/zend-stdlib": "~2.5",
@@ -27,6 +26,7 @@
         "phpunit/PHPUnit": "~4.0"
     },
     "suggest": {
+        "zendframework/zend-crypt": "Crammd5 support in SMTP Auth",
         "zendframework/zend-servicemanager": "Zend\\ServiceManager component"
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     },
     "require-dev": {
         "zendframework/zend-config": "~2.5",
+        "zendframework/zend-crypt": "~2.5",
         "zendframework/zend-servicemanager": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"


### PR DESCRIPTION
zend-crypt is rather optional, used in smtp auth only