### PR TITLE
Pin to stable deps known to be forwards-compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
     - php: 7
     - php: hhvm 
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,14 @@
     },
     "require": {
         "php": "^5.5 || ^7.0",
-        "zendframework/zend-crypt": "~2.5",
-        "zendframework/zend-loader": "~2.5",
-        "zendframework/zend-mime": "~2.5",
-        "zendframework/zend-stdlib": "~2.5",
-        "zendframework/zend-validator": "~2.5"
+        "zendframework/zend-crypt": "^2.6",
+        "zendframework/zend-loader": "^2.5",
+        "zendframework/zend-mime": "^2.5",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0",
+        "zendframework/zend-validator": "^2.6"
     },
     "require-dev": {
-        "zendframework/zend-config": "~2.5",
-        "zendframework/zend-servicemanager": "~2.5",
+        "zendframework/zend-config": "^2.6",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },


### PR DESCRIPTION
- Updates crypt, stdlib, validator, and config deps.
- Removes zend-servicemanager dev dependency; unused.
- Ensures PHP 7 builds are required.

(See https://github.com/zendframework/zend-mail/pull/66#issuecomment-185718365 for details.)