### PR TITLE
allow PHPUnit 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
 
 install:
-  - travis_retry composer install --no-interaction --ignore-platform-reqs
+  - travis_retry composer install --no-interaction
 
 script:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/phpunit --coverage-clover clover.xml ; fi

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "zendframework/zend-config": "^2.6",
         "fabpot/php-cs-fixer": "1.7.*",
-        "phpunit/PHPUnit": "~4.0"
+        "phpunit/PHPUnit": "^4.0 || ^5.2.9"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
I think this will be nice to use upstream maintained version, especially with PHP 7

With this, PHP < 5.6 will use the same version, PHP 5.6 and 7.0 wille use 5.2

Minimal version set to 5.2.9 because of https://github.com/sebastianbergmann/phpunit/pull/2083