### PR TITLE
Re-implement SmtpPluginManager as an AbstractPluginManager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,33 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+env:
+  global:
+    - SERVICE_MANAGER_VERSION="^3.0.3"
+
 matrix:
   fast_finish: true
   include:
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true
+    - php: 5.5
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
+    - php: 5.6
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: 7
+    - php: 7
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: hhvm 
+    - php: hhvm 
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
   allow_failures:
     - php: hhvm
 
@@ -33,6 +49,7 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION"
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,12 @@
     },
     "require-dev": {
         "zendframework/zend-config": "^2.6",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
+    },
+    "suggest": {
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3 when using SMTP to deliver messages"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/Protocol/SmtpPluginManager.php
+++ b/src/Protocol/SmtpPluginManager.php
@@ -9,7 +9,9 @@
 
 namespace Zend\Mail\Protocol;
 
-use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Factory\InvokableFactory;
+use Zend\ServiceManager\Exception\InvalidServiceException;
 
 /**
  * Plugin manager implementation for SMTP extensions.
@@ -17,40 +19,85 @@ use Interop\Container\ContainerInterface;
  * Enforces that SMTP extensions retrieved are instances of Smtp. Additionally,
  * it registers a number of default extensions available.
  */
-class SmtpPluginManager implements ContainerInterface
+class SmtpPluginManager extends AbstractPluginManager
 {
     /**
-     * Default set of plugins
-     *
-     * @var array
+     * Service aliases
      */
-    protected $plugins = [
-        'crammd5' => 'Zend\Mail\Protocol\Smtp\Auth\Crammd5',
-        'login'   => 'Zend\Mail\Protocol\Smtp\Auth\Login',
-        'plain'   => 'Zend\Mail\Protocol\Smtp\Auth\Plain',
-        'smtp'    => 'Zend\Mail\Protocol\Smtp',
+    protected $aliases = [
+        'crammd5' => Smtp\Auth\Crammd5::class,
+        'cramMd5' => Smtp\Auth\Crammd5::class,
+        'CramMd5' => Smtp\Auth\Crammd5::class,
+        'cramMD5' => Smtp\Auth\Crammd5::class,
+        'CramMD5' => Smtp\Auth\Crammd5::class,
+        'login'   => Smtp\Auth\Login::class,
+        'Login'   => Smtp\Auth\Login::class,
+        'plain'   => Smtp\Auth\Plain::class,
+        'Plain'   => Smtp\Auth\Plain::class,
+        'smtp'    => Smtp::class,
+        'Smtp'    => Smtp::class,
+        'SMTP'    => Smtp::class,
     ];
 
     /**
-     * Do we have the plugin?
+     * Service factories
      *
-     * @param  string $id
-     * @return bool
+     * @var array
      */
-    public function has($id)
-    {
-        return array_key_exists($id, $this->plugins);
-    }
+    protected $factories = [
+        Smtp\Auth\Crammd5::class => InvokableFactory::class,
+        Smtp\Auth\Login::class   => InvokableFactory::class,
+        Smtp\Auth\Plain::class   => InvokableFactory::class,
+        Smtp::class              => InvokableFactory::class,
+
+        // v2 normalized service names
+
+        'zendmailprotocolsmtpauthcrammd5' => InvokableFactory::class,
+        'zendmailprotocolsmtpauthlogin'   => InvokableFactory::class,
+        'zendmailprotocolsmtpauthplain'   => InvokableFactory::class,
+        'zendmailprotocolsmtp'              => InvokableFactory::class,
+    ];
+
     /**
-     * Retrieve the smtp plugin
+     * Plugins must be an instance of the Smtp class
      *
-     * @param  string $id
-     * @param  array $options
-     * @return AbstractProtocol
+     * @var string
      */
-    public function get($id, array $options = null)
+    protected $instanceOf = Smtp::class;
+
+    /**
+     * Validate a retrieved plugin instance (v3).
+     *
+     * @param object $plugin
+     * @throws InvalidServiceException
+     */
+    public function validate($plugin)
     {
-        $class = $this->plugins[$id];
-        return new $class($options);
+        if (! $plugin instanceof $this->instanceOf) {
+            throw new InvalidServiceException(sprintf(
+                'Plugin of type %s is invalid; must extend %s',
+                (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
+                Smtp::class
+            ));
+        }
+    }
+
+    /**
+     * Validate a retrieved plugin instance (v2).
+     *
+     * @param object $plugin
+     * @throws Exception\InvalidArgumentException
+     */
+    public function validatePlugin($plugin)
+    {
+        try {
+            $this->validate($plugin);
+        } catch (InvalidServiceException $e) {
+            throw new Exception\InvalidArgumentException(
+                $e->getMessage(),
+                $e->getCode(),
+                $e
+            );
+        }
     }
 }

--- a/src/Transport/Smtp.php
+++ b/src/Transport/Smtp.php
@@ -14,6 +14,7 @@ use Zend\Mail\Headers;
 use Zend\Mail\Message;
 use Zend\Mail\Protocol;
 use Zend\Mail\Protocol\Exception as ProtocolException;
+use Zend\ServiceManager\ServiceManager;
 
 /**
  * SMTP connection object
@@ -123,7 +124,7 @@ class Smtp implements TransportInterface
     public function getPluginManager()
     {
         if (null === $this->plugins) {
-            $this->setPluginManager(new Protocol\SmtpPluginManager());
+            $this->setPluginManager(new Protocol\SmtpPluginManager(new ServiceManager()));
         }
         return $this->plugins;
     }

--- a/test/Protocol/SmtpPluginManagerCompatibilityTest.php
+++ b/test/Protocol/SmtpPluginManagerCompatibilityTest.php
@@ -12,7 +12,7 @@ namespace ZendTest\Mail\Protocol;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Mail\Protocol\Smtp;
 use Zend\Mail\Protocol\SmtpPluginManager;
-use Zend\Mail\Protocol\Smtp\Exception\InvalidArgumentException;
+use Zend\Mail\Protocol\Exception\InvalidArgumentException;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\Test\CommonPluginManagerTrait;
 

--- a/test/Protocol/SmtpPluginManagerCompatibilityTest.php
+++ b/test/Protocol/SmtpPluginManagerCompatibilityTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-mail for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mail\Protocol;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Mail\Protocol\Smtp;
+use Zend\Mail\Protocol\SmtpPluginManager;
+use Zend\Mail\Protocol\Smtp\Exception\InvalidArgumentException;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+
+class SmtpPluginManagerCompatibilityTest extends TestCase
+{
+    use CommonPluginManagerTrait;
+
+    protected function getPluginManager()
+    {
+        return new SmtpPluginManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return InvalidArgumentException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        return Smtp::class;
+    }
+}


### PR DESCRIPTION
This patch re-implements the SmtpPluginManager as a zend-servicemanager AbstractPluginManager, as was the behavior before 2.6.0. As reported on #47, making the implementation standalone was a backwards compatibility break, as it was not an internal implementation only, but also the documented mechanism for providing additional featuresets and/or overriding the functionality of existing features.

To accomplish this, the following changes were made:

- Added a development requirement on zend-servicemanager `^2.7.5 || ^3.0.3`.
- Added a `suggest` section, recommending zend-servicemanager when using the SMTP transport.
- Added compatibility tests for the `SmtpPluginManager`, to assure equal behavior between v2 and v3 of zend-servicemanager.
- Updated `SmtpPluginManager` to extend `AbstractPluginManager` and define aliases and factories for the shipped protocol plugins.