### PR TITLE
Fix problem with uniqueIds and receiving Messages from Maildir

### DIFF
--- a/src/Storage/Maildir.php
+++ b/src/Storage/Maildir.php
@@ -294,7 +294,7 @@ class Maildir extends AbstractStorage
 
             ErrorHandler::start(E_NOTICE);
             list($uniq, $info) = explode(':', $entry, 2);
-            list(, $size) = explode(',', $uniq, 2);
+            list($uniq, $size) = explode(',', $uniq, 2);
             ErrorHandler::stop();
             if ($size && $size[0] == 'S' && $size[1] == '=') {
                 $size = substr($size, 2);


### PR DESCRIPTION
When using Zend\Mail\Storage\Writable\Maildir and saving mails to it an receiving the uniqueId, that uniqueId did never match the determined $uniq when reading the mail from Maildir.
uniq should be like ##########.####.####.@@@@@
uniq was like ##########.####.####.@@@@@,S=####
