### PR TITLE
Prepare standalone package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,10 @@
         "branch-alias": {
             "dev-master": "2.6-dev",
             "dev-develop": "2.7-dev"
+        },
+        "zf": {
+            "component": "Zend\\Mail",
+            "config-provider": "Zend\\Mail\\ConfigProvider"
         }
     },
     "autoload-dev": {

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-mail for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mail;
+
+class ConfigProvider
+{
+    /**
+     * Retrieve configuration for zend-mail package.
+     *
+     * @return array
+     */
+    public function __invoke()
+    {
+        return [
+            'dependencies' => $this->getDependencyConfig(),
+        ];
+    }
+
+    /**
+     * Retrieve dependency settings for zend-mail package.
+     *
+     * @return array
+     */
+    public function getDependencyConfig()
+    {
+        return [
+            'factories' => [
+                Protocol\SmtpPluginManager::class => Protocol\SmtpPluginManagerFactory::class,
+            ],
+        ];
+    }
+}

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-mail for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mail;
+
+class Module
+{
+    /**
+     * Retrieve zend-mail package configuration for zend-mvc context.
+     *
+     * @return array
+     */
+    public function getConfig()
+    {
+        $provider = new ConfigProvider();
+        return [
+            'service_manager' => $provider->getDependencyConfig(),
+        ];
+    }
+}

--- a/src/Protocol/SmtpPluginManager.php
+++ b/src/Protocol/SmtpPluginManager.php
@@ -55,7 +55,7 @@ class SmtpPluginManager extends AbstractPluginManager
         'zendmailprotocolsmtpauthcrammd5' => InvokableFactory::class,
         'zendmailprotocolsmtpauthlogin'   => InvokableFactory::class,
         'zendmailprotocolsmtpauthplain'   => InvokableFactory::class,
-        'zendmailprotocolsmtp'              => InvokableFactory::class,
+        'zendmailprotocolsmtp'            => InvokableFactory::class,
     ];
 
     /**

--- a/src/Protocol/SmtpPluginManagerFactory.php
+++ b/src/Protocol/SmtpPluginManagerFactory.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-mail for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mail\Protocol;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class SmtpPluginManagerFactory implements FactoryInterface
+{
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array
+     */
+    protected $creationOptions;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return SmtpPluginManager
+     */
+    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    {
+        return new SmtpPluginManager($container, $options ?: []);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return SmtpPluginManager
+     */
+    public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
+    {
+        return $this($container, $requestedName ?: SmtpPluginManager::class, $this->creationOptions);
+    }
+
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array $options
+     * @return void
+     */
+    public function setCreationOptions(array $options)
+    {
+        $this->creationOptions = $options;
+    }
+}

--- a/test/Protocol/SmtpPluginManagerFactoryTest.php
+++ b/test/Protocol/SmtpPluginManagerFactoryTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-mail for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mail\Protocol;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Mail\Protocol\Smtp;
+use Zend\Mail\Protocol\SmtpPluginManager;
+use Zend\Mail\Protocol\SmtpPluginManagerFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class SmtpPluginManagerFactoryTest extends TestCase
+{
+    public function testFactoryReturnsPluginManager()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $factory = new SmtpPluginManagerFactory();
+
+        $plugins = $factory($container, SmtpPluginManager::class);
+        $this->assertInstanceOf(SmtpPluginManager::class, $plugins);
+
+        if (method_exists($plugins, 'configure')) {
+            // zend-servicemanager v3
+            $this->assertAttributeSame($container, 'creationContext', $plugins);
+        } else {
+            // zend-servicemanager v2
+            $this->assertSame($container, $plugins->getServiceLocator());
+        }
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     */
+    public function testFactoryConfiguresPluginManagerUnderContainerInterop()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $smtp = $this->prophesize(Smtp::class)->reveal();
+
+        $factory = new SmtpPluginManagerFactory();
+        $plugins = $factory($container, SmtpPluginManager::class, [
+            'services' => [
+                'test' => $smtp,
+            ],
+        ]);
+        $this->assertSame($smtp, $plugins->get('test'));
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     */
+    public function testFactoryConfiguresPluginManagerUnderServiceManagerV2()
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $smtp = $this->prophesize(Smtp::class)->reveal();
+
+        $factory = new SmtpPluginManagerFactory();
+        $factory->setCreationOptions([
+            'services' => [
+                'test' => $smtp,
+            ],
+        ]);
+
+        $plugins = $factory->createService($container->reveal());
+        $this->assertSame($smtp, $plugins->get('test'));
+    }
+}


### PR DESCRIPTION
Adds:

- `Zend\Mail\Protocol\SmtpPluginManagerFactory`, for creating and returning an `SmtpPluginManagerFactory` instance.
- `Zend\Mail\ConfigProvider`, which maps the `SmtpPluginManager` service to the above factory.
- `Zend\Mail\Module`, which does the same, for a zend-mvc context.