### PR TITLE
Allow DNS Hostnames

### DIFF
--- a/src/Address.php
+++ b/src/Address.php
@@ -27,7 +27,7 @@ class Address implements Address\AddressInterface
      */
     public function __construct($email, $name = null)
     {
-        $emailAddressValidator = new EmailAddressValidator(Hostname::ALLOW_LOCAL);
+        $emailAddressValidator = new EmailAddressValidator(Hostname::ALLOW_DNS | Hostname::ALLOW_LOCAL);
         if (! is_string($email) || empty($email)) {
             throw new Exception\InvalidArgumentException('Email must be a valid email address');
         }

--- a/test/AddressTest.php
+++ b/test/AddressTest.php
@@ -67,4 +67,23 @@ class AddressTest extends \PHPUnit_Framework_TestCase
             ["foo@bar", "\r\nevilBody"],
         ];
     }
+
+    /**
+     * @dataProvider validSenderDataProvider
+     * @param string $email
+     * @param null|string $name
+     */
+    public function testSetAddressValidAddressObject($email, $name)
+    {
+        $address = new Address($email, $name);
+        $this->assertInstanceOf('\Zend\Mail\Address', $address);
+    }
+
+    public function validSenderDataProvider()
+    {
+        return [
+            // Description => [sender address, sender name],
+            'german IDN' => ['öäü@ä-umlaut.de', null],
+        ];
+    }
 }

--- a/test/HeadersTest.php
+++ b/test/HeadersTest.php
@@ -462,4 +462,13 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $headers->addHeaders(['Fake' => ["foo-bar\r\n\r\nevilContent"]]);
         $headers->forceLoading();
     }
+
+    public function testAddressListGetEncodedFieldValueWithUtf8Domain()
+    {
+        $to = new Header\To;
+        $to->setEncoding('UTF-8');
+        $to->getAddressList()->add('local-part@ä-umlaut.de');
+        $encodedValue = $to->getFieldValue(Header\HeaderInterface::FORMAT_ENCODED);
+        $this->assertEquals('local-part@xn---umlaut-4wa.de', $encodedValue);
+    }
 }


### PR DESCRIPTION
Zend\Mail\Address must instantiate Zend\Validator\EmailAddress with 'allow' |= Zend\Validator\Hostname::ALLOW_DNS for correct validation.
The current behavior is to only allow local domain parts. For most email adresses the validator still returns true, because 99% of the domains used match the ALLOW_LOCAL regex. But for IDN/UTF-8 domains the validator returns false.