### PR TITLE
one-off fixes

### DIFF
--- a/src/Storage/AbstractStorage.php
+++ b/src/Storage/AbstractStorage.php
@@ -256,7 +256,7 @@ abstract class AbstractStorage implements
     public function rewind()
     {
         $this->iterationMax = $this->countMessages();
-        $this->iterationPos = 1;
+        $this->iterationPos = 0;
     }
 
     /**
@@ -297,7 +297,7 @@ abstract class AbstractStorage implements
         if ($this->iterationMax === null) {
             $this->iterationMax = $this->countMessages();
         }
-        return $this->iterationPos && $this->iterationPos <= $this->iterationMax;
+        return $this->iterationPos < $this->iterationMax;
     }
 
     /**


### PR DESCRIPTION
- rewind() to posn. 0 rather than 1

- valid(): must return true at posn. 0 if that's a valid index, and
  false at posn. iterationMax

N.B. foreach() over the thing still works, even without the patch. I guess that's because AbstractStorage also implements ArrayAccess.