### PR TITLE
Message::getSender creates a blank Sender header

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -314,6 +314,10 @@ class Message
      */
     public function getSender()
     {
+        $headers = $this->getHeaders();
+        if (!$headers->has('sender')) {
+            return null;
+        }
         $header = $this->getHeaderByName('sender', __NAMESPACE__ . '\Header\Sender');
         return $header->getAddress();
     }

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -158,6 +158,13 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($this->message->getSender());
     }
 
+    public function testNullSenderDoesNotCreateHeader()
+    {
+        $sender = $this->message->getSender();
+        $headers = $this->message->getHeaders();
+        $this->assertFalse($headers->has('sender'));
+    }
+
     public function testSettingSenderCreatesAddressObject()
     {
         $this->message->setSender('zf-devteam@example.com');

--- a/test/Transport/SmtpTest.php
+++ b/test/Transport/SmtpTest.php
@@ -153,6 +153,28 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
         $this->assertContains($expectedMessage, $this->connection->getLog());
     }
 
+    public function testSendMinimalMailWithoutSender()
+    {
+        $headers = new Headers();
+        $headers->addHeaderLine('Date', 'Sun, 10 Jun 2012 20:07:24 +0200');
+        $message = new Message();
+        $message
+            ->setHeaders($headers)
+            ->setFrom('ralph.schindler@zend.com', 'Ralph Schindler')
+            ->setBody('testSendMinimalMailWithoutSender')
+            ->addTo('zf-devteam@zend.com', 'ZF DevTeam')
+        ;
+        $expectedMessage = "Date: Sun, 10 Jun 2012 20:07:24 +0200\r\n"
+                           . "From: Ralph Schindler <ralph.schindler@zend.com>\r\n"
+                           . "To: ZF DevTeam <zf-devteam@zend.com>\r\n"
+                           . "\r\n"
+                           . "testSendMinimalMailWithoutSender";
+
+        $this->transport->send($message);
+
+        $this->assertContains($expectedMessage, $this->connection->getLog());
+    }
+
     public function testReceivesMailArtifacts()
     {
         $message = $this->getMessage();


### PR DESCRIPTION
The `getSender()` method of `Message` unintentionally creates a blank Sender header.

The expected behaviour is to return `null` if the Sender header does not exist however the current implementation creates a blank Sender header in the process. Subsequent calls to getSender will return a blank header instead of the `null` that is expected.

This directly affects Transport\Smtp as getSender is used in the sending logic. Therefore, this PR has a test against Smtp as well as against Message. This might be redundant. It does however test expected Smtp functionality, so comments on that tests inclusion in the final patch are welcome.
