### PR TITLE
Fix documentation for setting the correct content-type

### DIFF
--- a/doc/book/message/attachments.md
+++ b/doc/book/message/attachments.md
@@ -32,7 +32,9 @@ $body->setParts([$html, $image]);
 
 $message = new Message();
 $message->setBody($body);
-$message->getHeaders()->addHeaderLine('Content-Type', 'multipart/related');
+
+$contentTypeHeader = $message->getHeaders()->get('Content-Type');
+$contentTypeHeader->setType('multipart/related');
 ```
 
 Note that the above code requires us to manually specify the message content
@@ -65,7 +67,9 @@ $body->setParts([$text, $html]);
 
 $message = new Message();
 $message->setBody($body);
-$message->getHeaders()->addHeaderLine('Content-Type', 'multipart/alternative');
+
+$contentTypeHeader = $message->getHeaders()->get('Content-Type');
+$contentTypeHeader->setType('multipart/alternative');
 ```
 
 The only differences from the first example are:
@@ -128,7 +132,9 @@ $body->setParts([$contentPart, $image]);
 
 $message = new Message();
 $message->setBody($body);
-$message->geHeaders()->addHeaderLine('Content-Type', 'multipart/related');
+
+$contentTypeHeader = $message->getHeaders()->get('Content-Type');
+$contentTypeHeader->setType('multipart/related');
 ```
 
 ## Setting custom MIME boundaries


### PR DESCRIPTION
### Problem

I want to send emails with html content and a text fallback for client that have HTML disabled or are incabable of it.

I've tried using the documented way for it: [zend-mail/multipartalternative-content](https://zendframework.github.io/zend-mail/message/attachments/#multipartalternative-content)
and it didnt work in Thunderbird 45.3.0 Mac OS X. I didnt test any other clients though.
Both content (text and html) were displayed, so Thunderbird didnt interpret this as an alternative, but as an attachment. Looking at the source code revealed that the "Content-Type" Header was set 2 times:

```
Content-Type: multipart/mixed;
 boundary="=_e24aa7041d46737eb2b762f6bfeb2d98"
Content-Type: multipart/alternative
```
### Solution

Changing my code from

```
$message->getHeaders()->addHeaderLine('Content-Type', 'multipart/alternative');
```

to

```
$contentTypeHeader = $message->getHeaders()->get('Content-Type');
$contentTypeHeader->setType('multipart/related');
```

worked and Thunderbird displays the correct content for the chosen view-mode.

I'm not entirely sure if this is a Thunderbird issue (and the latter Content-Type should overwrite the former) or if this is a bug in zend-mail or just the documentation. If its the latter this PR will fix the documentation. 
### Used version(s):

```
zendframework/zend-config                    2.6.0
zendframework/zend-escaper                   2.5.2              
zendframework/zend-eventmanager              3.0.1
zendframework/zend-http                      2.5.5
zendframework/zend-mail                      2.7.1
zendframework/zend-mime                      2.6.0              
zendframework/zend-validator                 2.8.1
```
