### PR TITLE
Protocol\AbstractProtocol: verbose errors

### DIFF
--- a/src/Protocol/AbstractProtocol.php
+++ b/src/Protocol/AbstractProtocol.php
@@ -206,7 +206,14 @@ abstract class AbstractProtocol
         $errorStr = '';
 
         // open connection
-        $this->socket = @stream_socket_client($remote, $errorNum, $errorStr, self::TIMEOUT_CONNECTION);
+        set_error_handler(
+            function ($error, $message = '') {
+                throw new Exception\RuntimeException(sprintf('Could not open socket: %s', $message), $error);
+            },
+            E_WARNING
+        );
+        $this->socket = stream_socket_client($remote, $errorNum, $errorStr, self::TIMEOUT_CONNECTION);
+        restore_error_handler();
 
         if ($this->socket === false) {
             if ($errorNum == 0) {

--- a/test/Protocol/SmtpTest.php
+++ b/test/Protocol/SmtpTest.php
@@ -107,8 +107,8 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
     {
         $smtp = new TestAsset\ErroneousSmtp();
 
-        $this->setExpectedExceptionRegExp('Zend\Mail\Protocol\Exception\RuntimeException', '/Name or service not known/');
+        $this->setExpectedExceptionRegExp('Zend\Mail\Protocol\Exception\RuntimeException', '/nonexistentremote/');
 
-        $smtp->connect('tcp://nonexistentdomain:25');
+        $smtp->connect('nonexistentremote');
     }
 }

--- a/test/Protocol/SmtpTest.php
+++ b/test/Protocol/SmtpTest.php
@@ -102,4 +102,13 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
         $this->connection->disconnect();
         $this->assertFalse($this->connection->getAuth());
     }
+
+    public function testConnectHasVerboseErrors()
+    {
+        $smtp = new TestAsset\ErroneousSmtp();
+
+        $this->setExpectedExceptionRegExp('Zend\Mail\Protocol\Exception\RuntimeException', '/Name or service not known/');
+
+        $smtp->connect('tcp://nonexistentdomain:25');
+    }
 }

--- a/test/Protocol/TestAsset/ErroneousSmtp.php
+++ b/test/Protocol/TestAsset/ErroneousSmtp.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mail\Protocol\TestAsset;
+
+use Zend\Mail\Protocol\AbstractProtocol;
+
+/**
+ * Expose AbstractProtocol behaviour
+ */
+final class ErroneousSmtp extends AbstractProtocol
+{
+    public function connect($customRemote = null)
+    {
+        return $this->_connect($customRemote);
+    }
+}


### PR DESCRIPTION
Recently an update of openssl stopped our app (aright) becase one of our partner had messy servers:

```
$ php -r 'var_dump(stream_socket_client("ssl://hide.me:465", $errorNum, $errorStr));var_dump($errorNum, $errorStr);'

Warning: stream_socket_client(): SSL operation failed with code 1. OpenSSL Error messages:
error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure in Command line code on line 1

Warning: stream_socket_client(): Failed to enable crypto in Command line code on line 1

Warning: stream_socket_client(): unable to connect to ssl://hide.me:465 (Unknown error) in Command line code on line 1
bool(false)
int(0)
string(0) ""
```

But it took us a while to get the right error, because an anonym `Could not open socket` was the only message thrown by the smtp protocol.
Also, many times `$errorNum` and `$errorStr` are empty.

With this PR the error-suppressing operator `@` is deleted and a specific error handler to exception function handles the possible warnings.
