### PR TITLE
Protocol\Smtp: toggle QUIT>221 command at disconnect

### DIFF
--- a/test/Protocol/SmtpTest.php
+++ b/test/Protocol/SmtpTest.php
@@ -102,4 +102,31 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
         $this->connection->disconnect();
         $this->assertFalse($this->connection->getAuth());
     }
+
+    public function testCanAvoidQuitRequest()
+    {
+        $this->assertTrue($this->connection->useCompleteQuit(), 'Default behaviour must be BC');
+
+        $this->connection->resetLog();
+        $this->connection->connect();
+        $this->connection->helo();
+        $this->connection->disconnect();
+
+        $this->assertContains('QUIT', $this->connection->getLog());
+
+        $this->connection->setUseCompleteQuit(false);
+        $this->assertFalse($this->connection->useCompleteQuit());
+
+        $this->connection->resetLog();
+        $this->connection->connect();
+        $this->connection->helo();
+        $this->connection->disconnect();
+
+        $this->assertNotContains('QUIT', $this->connection->getLog());
+
+        $connection = new SmtpProtocolSpy(array(
+            'use_complete_quit' => false,
+        ));
+        $this->assertFalse($connection->useCompleteQuit());
+    }
 }

--- a/test/Protocol/SmtpTest.php
+++ b/test/Protocol/SmtpTest.php
@@ -124,9 +124,9 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotContains('QUIT', $this->connection->getLog());
 
-        $connection = new SmtpProtocolSpy(array(
+        $connection = new SmtpProtocolSpy([
             'use_complete_quit' => false,
-        ));
+        ]);
         $this->assertFalse($connection->useCompleteQuit());
     }
 }


### PR DESCRIPTION
Original issue: https://github.com/zendframework/zend-mail/pull/27

When a SMTP server implements a timeout, a script like this is a pain in the ass:

``` php
$transport = new Zend\Mail\Transport\Smtp();

$message = new Zend\Mail\Message();
$message->setFrom('test@test.com');
$message->addTo('test@test.com');
$message->setSubject('Test ' . date('H:i:s'));
$message->setBody('Test ' . date('H:i:s'));

$transport->send($message);
var_dump('E-mail sent');

sleep(305);

var_dump('Soon to exit...');
exit;

// E-mail sent
// Soon to exit...
// Notice: fwrite(): send of 6 bytes failed with errno=32 Broken pipe in ./zend-mail/src/Protocol/AbstractProtocol.php on line 255
// Fatal error: Uncaught Zend\Mail\Protocol\Exception\RuntimeException: Could not read from 127.0.0.1 in ./zend-mail/src/Protocol/AbstractProtocol.php:301
```

While the other features mentioned in #27 can be implemented in a custom way using OOP, this one cannot.

If a user wants to use `Protocol\Smtp` _and_ `Protocol\Smtp\Auth\Login`, the fact that:
1. `quit()` is hardcoded into `Protocol\Smtp::_disconnect()`
2. `Protocol\Smtp::_disconnect()` is hardcoded into `Protocol\AbstractProtocol::__destruct()`

Makes impossible to customize zendframework/zend-mail component, even with subclassing, without rewriting the core code lines of `Zend\Protocol\*`

With this PR a user can decide wether or not send the QUIT at __destruct / exit:

``` php
$transport = new Zend\Mail\Transport\Smtp(new Zend\Mail\Transport\SmtpOptions(array(
    'connection_class'  => 'smtp', // or plain, login, crammd5
    'connection_config' => [
        'use_complete_quit' => false,
    ],
)));
```

As soon as the PR is accepted, I'll PR to the doc.
