### PR TITLE
Make documentation more clear

### DIFF
--- a/doc/book/message/attachments.md
+++ b/doc/book/message/attachments.md
@@ -112,10 +112,8 @@ $content = new MimeMessage();
 $content->setParts([$text, $html]);
 
 $contentPart = new MimePart($content->generateMessage());
-$contentPart->type = sprintf(
-    "multipart/alternative\n boundary=\"%s\",
-    $content->getMime()->boundary()
-);
+$contentPart->boundary = $content->getMime()->boundary();
+$contentPart->type = 'multipart/alternative';
 
 $image = new MimePart(fopen($pathToImage, 'r'));
 $image->type = 'image/jpeg';

--- a/doc/book/message/attachments.md
+++ b/doc/book/message/attachments.md
@@ -128,7 +128,7 @@ $body->setParts([$contentPart, $image]);
 
 $message = new Message();
 $message->setBody($body);
-$message->geHeaders()->addHeaderLine('Content-Type', 'multipart/related');
+$message->getHeaders()->addHeaderLine('Content-Type', 'multipart/related');
 ```
 
 ## Setting custom MIME boundaries


### PR DESCRIPTION
There is a typo when calling the `getHeaders` method.

I split the assignment of the `type` on the `$contentPart` object. I think removing the `sprintf` function makes the code more clear.
