### PR TITLE
Require $this->headers to be instance of Headers

### DIFF
--- a/src/Storage/Part.php
+++ b/src/Storage/Part.php
@@ -294,10 +294,16 @@ class Part implements RecursiveIterator, Part\PartInterface
      */
     public function getHeader($name, $format = null)
     {
-        $header = $this->getHeaders()->get($name);
+        $headers = $this->getHeaders();
+        if (!($headers instanceof Headers)) {
+            throw new Exception\RuntimeException(
+                '$this->headers must be an instance of Headers'
+            );
+        }
+        $header = $headers->get($name);
         if ($header === false) {
             $lowerName = strtolower(preg_replace('%([a-z])([A-Z])%', '\1-\2', $name));
-            $header = $this->getHeaders()->get($lowerName);
+            $header = $headers->get($lowerName);
             if ($header === false) {
                 throw new Exception\InvalidArgumentException(
                     "Header with Name $name or $lowerName not found"

--- a/src/Storage/Part.php
+++ b/src/Storage/Part.php
@@ -389,7 +389,13 @@ class Part implements RecursiveIterator, Part\PartInterface
      */
     public function __isset($name)
     {
-        return $this->getHeaders()->has($name);
+        $headers = $this->getHeaders();
+        if (!($headers instanceof Headers)) {
+            throw new Exception\RuntimeException(
+                '$this->headers must be an instance of Headers'
+            );
+        }
+        return $headers->has($name);
     }
 
     /**


### PR DESCRIPTION
Turns a fatal error into a catchable Exception (which allows users to have a helpful stack trace).

This sort of change will be unnecessary in PHP 7 (hooray return type declarations and catchable `TypeError`s).