### PR TITLE
added ext-iconv to require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     },
     "require": {
         "php": "^5.5 || ^7.0",
+        "ext-iconv": "*",
         "zendframework/zend-loader": "^2.5",
         "zendframework/zend-mime": "^2.5",
         "zendframework/zend-stdlib": "^2.7 || ^3.0",


### PR DESCRIPTION
make it require in the first place to avoid user get error when using it:

```bash
Call to undefined function Zend\Mail\Header\iconv_mime_decode()
```
