### PR TITLE
Added DocBlock for `Bcc` class properties

### DIFF
--- a/src/Header/Bcc.php
+++ b/src/Header/Bcc.php
@@ -11,6 +11,13 @@ namespace Zend\Mail\Header;
 
 class Bcc extends AbstractAddressList
 {
+    /**
+     * @var string
+     */
     protected $fieldName = 'Bcc';
+    
+    /**
+     * @var string
+     */
     protected static $type = 'bcc';
 }


### PR DESCRIPTION
According to PHP Standard Requirements there should be a line between class properties.

* Added DocBlock for property `fieldName`
* Added DocBlock for property `type`