### PR TITLE
skip test which requires intl extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "suggest": {
+        "ext-intl": "Handle IDN in AddressList hostnames",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3 when using SMTP to deliver messages",
         "zendframework/zend-crypt": "Crammd5 support in SMTP Auth"
     },

--- a/test/HeadersTest.php
+++ b/test/HeadersTest.php
@@ -471,6 +471,9 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $headers->forceLoading();
     }
 
+    /**
+     * @requires extension intl
+     */
     public function testAddressListGetEncodedFieldValueWithUtf8Domain()
     {
         $to = new Header\To;


### PR DESCRIPTION
skip test which requires intl extension, also add such dependency to composer suggest.