### PR TITLE
TLS: allow any protocol version

### DIFF
--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -13,6 +13,8 @@ use Zend\Stdlib\ErrorHandler;
 
 class Imap
 {
+    use ProtocolTrait;
+
     /**
      * Default timeout in seconds for initiating session
      */
@@ -102,7 +104,7 @@ class Imap
 
         if ($isTls) {
             $result = $this->requestAndResponse('STARTTLS');
-            $result = $result && stream_socket_enable_crypto($this->socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
+            $result = $result && stream_socket_enable_crypto($this->socket, true, $this->getCryptoMethod());
             if (! $result) {
                 throw new Exception\RuntimeException('cannot enable TLS');
             }

--- a/src/Protocol/Pop3.php
+++ b/src/Protocol/Pop3.php
@@ -13,6 +13,8 @@ use Zend\Stdlib\ErrorHandler;
 
 class Pop3
 {
+    use ProtocolTrait;
+
     /**
      * Default timeout in seconds for initiating session
      */
@@ -113,7 +115,7 @@ class Pop3
 
         if ($isTls) {
             $this->request('STLS');
-            $result = stream_socket_enable_crypto($this->socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
+            $result = stream_socket_enable_crypto($this->socket, true, $this->getCryptoMethod());
             if (! $result) {
                 throw new Exception\RuntimeException('cannot enable TLS');
             }

--- a/src/Protocol/ProtocolTrait.php
+++ b/src/Protocol/ProtocolTrait.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mail\Protocol;
+
+/**
+ * https://bugs.php.net/bug.php?id=69195
+ */
+trait ProtocolTrait
+{
+    public function getCryptoMethod()
+    {
+        // Allow the best TLS version(s) we can
+        $cryptoMethod = STREAM_CRYPTO_METHOD_TLS_CLIENT;
+
+        // PHP 5.6.7 dropped inclusion of TLS 1.1 and 1.2 in STREAM_CRYPTO_METHOD_TLS_CLIENT
+        // so add them back in manually if we can
+        if (defined('STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT')) {
+            $cryptoMethod |= STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+            $cryptoMethod |= STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
+        }
+
+        return $cryptoMethod;
+    }
+}

--- a/src/Protocol/Smtp.php
+++ b/src/Protocol/Smtp.php
@@ -17,6 +17,8 @@ namespace Zend\Mail\Protocol;
  */
 class Smtp extends AbstractProtocol
 {
+    use ProtocolTrait;
+
     /**
      * The transport method for the socket
      *
@@ -176,7 +178,7 @@ class Smtp extends AbstractProtocol
         if ($this->secure == 'tls') {
             $this->_send('STARTTLS');
             $this->_expect(220, 180);
-            if (! stream_socket_enable_crypto($this->socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT)) {
+            if (! stream_socket_enable_crypto($this->socket, true, $this->getCryptoMethod())) {
                 throw new Exception\RuntimeException('Unable to connect via TLS');
             }
             $this->ehlo($host);

--- a/test/Protocol/ProtocolTraitTest.php
+++ b/test/Protocol/ProtocolTraitTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mail\Protocol;
+
+use Zend\Mail\Protocol\ProtocolTrait;
+
+/**
+ * @group   Zend_Mail
+ * @covers  Zend\Mail\Protocol\ProtocolTrait
+ */
+class ProtocolTraitTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @requires PHP 5.6.7
+     */
+    public function testTls12Version()
+    {
+        $mock = $this->getMockForTrait(ProtocolTrait::class);
+
+        $this->assertNotEmpty(STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT & $mock->getCryptoMethod(), 'TLSv1.2 must be present in crypto method list');
+    }
+}


### PR DESCRIPTION
Since PHP 5.6.7 the constant `STREAM_CRYPTO_METHOD_TLS_CLIENT` doesn't refer to *any* TLS version, but only to TLS 1.0.

As of yet every zend-mail users are forced to use TLS 1.0 version, and TLS 1.1 and TLS 1.2 are excluded.
We need to readd them manually.

1. https://3v4l.org/llTT8
1. [stream_socket_enable_crypto](https://secure.php.net/manual/en/function.stream-socket-enable-crypto.php) manual page
1. [PHP 5.6.7 revert commit](https://bugs.php.net/bug.php?id=69195)
1. [PHPMailer evidence](https://github.com/PHPMailer/PHPMailer/blob/v5.2.23/class.smtp.php#L354-L370)
1. [New RFC for PHP 7.2](https://wiki.php.net/rfc/improved-tls-constants)

I consider this a **very urgent** fix.