### PR TITLE
update phpunit dep for expectException

### DIFF
--- a/test/Protocol/SmtpPluginManagerCompatibilityTest.php
+++ b/test/Protocol/SmtpPluginManagerCompatibilityTest.php
@@ -16,6 +16,9 @@ use Zend\Mail\Protocol\Exception\InvalidArgumentException;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\Test\CommonPluginManagerTrait;
 
+/**
+ * @requires PHPUnit 5.2
+ */
 class SmtpPluginManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;


### PR DESCRIPTION
this should fix travis errors that **every PR** in this project is suffering.

```
PHP Fatal error:
Call to undefined method
ZendTest\Mail\Protocol\SmtpPluginManagerCompatibilityTest::expectException()
in /home/travis/build/zendframework/zend-mail/vendor/zendframework/zend-servicemanager/src/Test/CommonPluginManagerTrait.php on line 56
```

this is because `SmtpPluginManagerCompatibilityTest` uses trait from other project `CommonPluginManagerTrait` which uses `expectException` phpunit method.

specified phpunit dependency that has such method available