### PR TITLE
unable to parse To headers with semicolon separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file, in reverse 
 - [#213](https://github.com/zendframework/zend-mail/pull/213) re-adds support for PHP 5.6 and 7.0; ZF policy is never
   to bump the major version of a PHP requirement unless the package is bumping major version.
 
+### Changed
+
+- Nothing.
+
 ### Deprecated
 
 - Nothing.
@@ -19,7 +23,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#147](https://github.com/zendframework/zend-mail/pull/147) fixes how address lists are parsed, expanding the functionality to allow either
+  `,` or `;` delimiters (or both in combination).
 
 ## 2.9.0 - 2017-03-01
 

--- a/src/AddressList.php
+++ b/src/AddressList.php
@@ -31,7 +31,9 @@ class AddressList implements Countable, Iterator
     {
         if (is_string($emailOrAddress)) {
             $emailOrAddress = $this->createAddress($emailOrAddress, $name);
-        } elseif (! $emailOrAddress instanceof Address\AddressInterface) {
+        }
+
+        if (! $emailOrAddress instanceof Address\AddressInterface) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects an email address or %s\Address object as its first argument; received "%s"',
                 __METHOD__,
@@ -65,14 +67,17 @@ class AddressList implements Countable, Iterator
         foreach ($addresses as $key => $value) {
             if (is_int($key) || is_numeric($key)) {
                 $this->add($value);
-            } elseif (is_string($key)) {
-                $this->add($key, $value);
-            } else {
+                continue;
+            }
+
+            if (! is_string($key)) {
                 throw new Exception\RuntimeException(sprintf(
                     'Invalid key type in provided addresses array ("%s")',
                     (is_object($key) ? get_class($key) : var_export($key, 1))
                 ));
             }
+
+            $this->add($key, $value);
         }
         return $this;
     }

--- a/src/Header/AbstractAddressList.php
+++ b/src/Header/AbstractAddressList.php
@@ -80,6 +80,7 @@ abstract class AbstractAddressList implements HeaderInterface
 
         $values = array_filter($values);
 
+        /** @var AddressList $addressList */
         $addressList = $header->getAddressList();
         foreach ($values as $address) {
             $addressList->addFromString($address);

--- a/src/Header/AbstractAddressList.php
+++ b/src/Header/AbstractAddressList.php
@@ -50,7 +50,7 @@ abstract class AbstractAddressList implements HeaderInterface
         // split value on ","
         $fieldValue = str_replace(Headers::FOLDING, ' ', $fieldValue);
         $fieldValue = preg_replace('/[^:]+:([^;]*);/', '$1,', $fieldValue);
-        $values = str_getcsv($fieldValue, ',');
+        $values = AddressListParser::parse($fieldValue);
 
         $wasEncoded = false;
         array_walk(

--- a/src/Header/AddressListParser.php
+++ b/src/Header/AddressListParser.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-mail for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-mail/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Mail\Header;
+
+use function in_array;
+
+class AddressListParser
+{
+    const CHAR_QUOTES = ['\'', '"'];
+    const CHAR_DELIMS = [',', ';'];
+    const CHAR_ESCAPE = '\\';
+
+    /**
+     * @param string $value
+     * @return array
+     */
+    public static function parse($value)
+    {
+        $values            = [];
+        $length            = strlen($value);
+        $currentValue      = '';
+        $inEscape          = false;
+        $inQuote           = false;
+        $currentQuoteDelim = null;
+
+        for ($i = 0; $i < $length; $i += 1) {
+            $char = $value[$i];
+
+            // If we are in an escape sequence, append the character and continue.
+            if ($inEscape) {
+                $currentValue .= $char;
+                $inEscape = false;
+                continue;
+            }
+
+            // If we are not in a quoted string, and have a delimiter, append
+            // the current value to the list, and reset the current value.
+            if (in_array($char, self::CHAR_DELIMS, true) && ! $inQuote) {
+                $values [] = $currentValue;
+                $currentValue = '';
+                continue;
+            }
+
+            // Append the character to the current value
+            $currentValue .= $char;
+
+            // Escape sequence discovered.
+            if (self::CHAR_ESCAPE === $char) {
+                $inEscape = true;
+                continue;
+            }
+
+            // If the character is not a quote character, we are done
+            // processing it.
+            if (! in_array($char, self::CHAR_QUOTES)) {
+                continue;
+            }
+
+            // If the character matches a previously matched quote delimiter,
+            // we reset our quote status and the currently opened quote
+            // delimiter.
+            if ($char === $currentQuoteDelim) {
+                $inQuote = false;
+                $currentQuoteDelim = null;
+                continue;
+            }
+
+            // Otherwise, we're starting a quoted string.
+            $inQuote = true;
+            $currentQuoteDelim = $char;
+        }
+
+        // If we reached the end of the string and still have a current value,
+        // append it to the list (no delimiter was reached).
+        if ('' !== $currentValue) {
+            $values [] = $currentValue;
+        }
+
+        return $values;
+    }
+}

--- a/test/AddressListTest.php
+++ b/test/AddressListTest.php
@@ -128,5 +128,8 @@ class AddressListTest extends TestCase
         $addressList = $to->getAddressList();
 
         $this->assertEquals('Some User', $addressList->get('some.user@example.com')->getName());
+        $this->assertTrue($addressList->has('uzer2.surname@example.org'));
+        $this->assertTrue($addressList->has('asda.fasd@example.net'));
+        $this->assertTrue($addressList->has('root@example.org'));
     }
 }

--- a/test/AddressListTest.php
+++ b/test/AddressListTest.php
@@ -10,6 +10,7 @@ namespace ZendTest\Mail;
 use PHPUnit\Framework\TestCase;
 use Zend\Mail\Address;
 use Zend\Mail\AddressList;
+use Zend\Mail\Header;
 
 /**
  * @group      Zend_Mail
@@ -104,5 +105,22 @@ class AddressListTest extends TestCase
         $this->assertTrue($this->list->has('zf-devteam@zend.com'));
         $address = $this->list->get('zf-devteam@zend.com');
         $this->assertNull($address->getName());
+    }
+
+
+    /**
+     * Microsoft Outlook sent emails are semicolon separated
+     *
+     * @see https://blogs.msdn.microsoft.com/oldnewthing/20150119-00/?p=44883
+     */
+    public function testSemicolonSeparator()
+    {
+        $header = 'Some User <some.user@example.com>; uzer2.surname@example.org; asda.fasd@example.net, root@example.org';
+
+        // this throws: 'The input exceeds the allowed length'
+        $to = Header\To::fromString('To:' . $header);
+        $addressList = $to->getAddressList();
+
+        $this->assertEquals('Some User', $addressList->get('some.user@example.com')->getName());
     }
 }


### PR DESCRIPTION
i wonder why Zend\Mail does not split on semicolon?

- it causes parse error on headers that are semicolon separated: `To: user1@domain.com; user2@domain.org`. to my knowledge outlook sends out such mails: [link](https://blogs.msdn.microsoft.com/oldnewthing/20150119-00/?p=44883)
- it causes "group" feature to be misparsed: `To: undisclosed recipients:; `. [another example](https://github.com/pear/Mail/blob/v1.4.1/Mail/RFC822.php#L62-L64)

this PR adds testcase that should not fail