### PR TITLE
AddressList does not parse address with parens in name field properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
+- [#148](https://github.com/zendframework/zend-mail/pull/148) adds the optional constructor argument `$comment` and the method `getComment()` to the class
+  `Zend\Mail\Address`. When a comment is present, `toString()` will include it in the representation.
+
+- [#148](https://github.com/zendframework/zend-mail/pull/148) adds the method `Zend\Mail\Address::fromString(string $address, $comment = null) : Address`.
+  The method can be used to generate an instance from a string containing a `(name)?<email>` value.
+  The `$comment` argument can be used to associate a comment with the address.
+
 - [#213](https://github.com/zendframework/zend-mail/pull/213) re-adds support for PHP 5.6 and 7.0; ZF policy is never
   to bump the major version of a PHP requirement unless the package is bumping major version.
 
@@ -22,6 +29,9 @@ All notable changes to this project will be documented in this file, in reverse 
 - Nothing.
 
 ### Fixed
+
+- [#148](https://github.com/zendframework/zend-mail/pull/148) fixes how `Zend\Mail\Header\AbstractAddressList` parses address values, ensuring
+  that they now retain any address comment discovered to include in the generated `Zend\Mail\Address` instances.
 
 - [#147](https://github.com/zendframework/zend-mail/pull/147) fixes how address lists are parsed, expanding the functionality to allow either
   `,` or `;` delimiters (or both in combination).

--- a/src/Address.php
+++ b/src/Address.php
@@ -12,17 +12,56 @@ use Zend\Validator\Hostname;
 
 class Address implements Address\AddressInterface
 {
+    protected $comment;
     protected $email;
     protected $name;
+
+    /**
+     * Create an instance from a string value.
+     *
+     * Parses a string representing a single address. If it is a valid format,
+     * it then creates and returns an instance of itself using the name and
+     * email it has parsed from the value.
+     *
+     * @param string $address
+     * @param null|string $comment Comment associated with the address, if any.
+     * @throws Exception\InvalidArgumentException
+     * @return self
+     */
+    public static function fromString($address, $comment = null)
+    {
+        if (! preg_match('/^((?P<name>.*)<(?P<namedEmail>[^>]+)>|(?P<email>.+))$/', $address, $matches)) {
+            throw new Exception\InvalidArgumentException('Invalid address format');
+        }
+
+        $name = null;
+        if (isset($matches['name'])) {
+            $name = trim($matches['name']);
+        }
+        if (empty($name)) {
+            $name = null;
+        }
+
+        if (isset($matches['namedEmail'])) {
+            $email = $matches['namedEmail'];
+        }
+        if (isset($matches['email'])) {
+            $email = $matches['email'];
+        }
+        $email = trim($email);
+
+        return new static($email, $name, $comment);
+    }
 
     /**
      * Constructor
      *
      * @param  string $email
      * @param  null|string $name
+     * @param  null|string $comment
      * @throws Exception\InvalidArgumentException
      */
-    public function __construct($email, $name = null)
+    public function __construct($email, $name = null, $comment = null)
     {
         $emailAddressValidator = new EmailAddressValidator(Hostname::ALLOW_DNS | Hostname::ALLOW_LOCAL);
         if (! is_string($email) || empty($email)) {
@@ -51,6 +90,10 @@ class Address implements Address\AddressInterface
         }
 
         $this->email = $email;
+
+        if (null !== $comment) {
+            $this->comment = $comment;
+        }
     }
 
     /**
@@ -74,18 +117,49 @@ class Address implements Address\AddressInterface
     }
 
     /**
+     * Retrieve comment, if any
+     *
+     * @return null|string
+     */
+    public function getComment()
+    {
+        return $this->comment;
+    }
+
+    /**
      * String representation of address
      *
      * @return string
      */
     public function toString()
     {
-        $string = '<' . $this->getEmail() . '>';
-        $name   = $this->getName();
+        $string = sprintf('<%s>', $this->getEmail());
+        $name   = $this->constructName();
         if (null === $name) {
             return $string;
         }
 
-        return $name . ' ' . $string;
+        return sprintf('%s %s', $name, $string);
+    }
+
+    /**
+     * Constructs the name string
+     *
+     * If a comment is present, appends the comment (commented using parens) to
+     * the name before returning it; otherwise, returns just the name.
+     *
+     * @return null|string
+     */
+    private function constructName()
+    {
+        $name = $this->getName();
+        $comment = $this->getComment();
+
+        if ($comment === null || $comment === '') {
+            return $name;
+        }
+
+        $string = sprintf('%s (%s)', $name, $comment);
+        return trim($string);
     }
 }

--- a/src/AddressList.php
+++ b/src/AddressList.php
@@ -88,32 +88,13 @@ class AddressList implements Countable, Iterator
      *  - dev@zf.com
      *
      * @param string $address
+     * @param null|string $comment Comment associated with the address, if any.
      * @throws Exception\InvalidArgumentException
      * @return AddressList
      */
-    public function addFromString($address)
+    public function addFromString($address, $comment = null)
     {
-        if (! preg_match('/^((?P<name>.*)<(?P<namedEmail>[^>]+)>|(?P<email>.+))$/', $address, $matches)) {
-            throw new Exception\InvalidArgumentException('Invalid address format');
-        }
-
-        $name = null;
-        if (isset($matches['name'])) {
-            $name = trim($matches['name']);
-        }
-        if (empty($name)) {
-            $name = null;
-        }
-
-        if (isset($matches['namedEmail'])) {
-            $email = $matches['namedEmail'];
-        }
-        if (isset($matches['email'])) {
-            $email = $matches['email'];
-        }
-        $email = trim($email);
-
-        return $this->add($email, $name);
+        $this->add(Address::fromString($address, $comment));
     }
 
     /**

--- a/test/AddressListTest.php
+++ b/test/AddressListTest.php
@@ -19,7 +19,7 @@ use Zend\Mail\Header;
  */
 class AddressListTest extends TestCase
 {
-    /** @var AddressList $list */
+    /** @var AddressList */
     private $list;
 
     public function setUp()
@@ -93,6 +93,17 @@ class AddressListTest extends TestCase
         $this->assertTrue($this->list->has('zf-devteam@zend.com'));
         $this->assertTrue($this->list->has('zf-contributors@lists.zend.com'));
         $this->assertTrue($this->list->has('fw-announce@lists.zend.com'));
+    }
+
+    public function testLosesParensInName()
+    {
+        $header = '"Supports (E-mail)" <support@example.org>';
+
+        $to = Header\To::fromString('To:' . $header);
+        $addressList = $to->getAddressList();
+        $address = $addressList->get('support@example.org');
+        $this->assertEquals('Supports (E-mail)', $address->getName());
+        $this->assertEquals('support@example.org', $address->getEmail());
     }
 
     public function testDoesNotStoreDuplicatesAndFirstWins()

--- a/test/AddressListTest.php
+++ b/test/AddressListTest.php
@@ -102,7 +102,8 @@ class AddressListTest extends TestCase
         $to = Header\To::fromString('To:' . $header);
         $addressList = $to->getAddressList();
         $address = $addressList->get('support@example.org');
-        $this->assertEquals('Supports (E-mail)', $address->getName());
+        $this->assertEquals('Supports', $address->getName());
+        $this->assertEquals('E-mail', $address->getComment());
         $this->assertEquals('support@example.org', $address->getEmail());
     }
 


### PR DESCRIPTION
```
"Supports (E-mail)" <support@example.org>
```

this gets parsed as `Support`, not as expected `Supports (E-mail)`