### PR TITLE
Dummy value in SSL config

### DIFF
--- a/src/Protocol/Smtp.php
+++ b/src/Protocol/Smtp.php
@@ -122,6 +122,10 @@ class Smtp extends AbstractProtocol
                         $port = 465;
                     }
                     break;
+                    
+                case '':
+                case 'none':
+                    break;
 
                 default:
                     throw new Exception\InvalidArgumentException($config['ssl'] . ' is unsupported SSL type');


### PR DESCRIPTION
Allow defining a dummy value for SSL config in SMTP protocol.
Convenient configuration for continuous delivery workflows (having a generic config file, replacing token values while packaging)