### PR TITLE
Update PHPUnit to 5.7 + 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ cache:
 
 env:
   global:
+    - COMPOSER_ARGS="--no-interaction"
+    - COVERAGE_DEPS="satooshi/php-coveralls"
+    - LEGACY_DEPS="phpunit/phpunit"
     - SERVICE_MANAGER_VERSION="^3.0.3"
     - SITE_URL: https://zendframework.github.io/zend-mail
     - GH_USER_NAME: "Matthew Weier O'Phinney"
@@ -27,37 +30,68 @@ matrix:
   include:
     - php: 5.5
       env:
+        - DEPS=lowest
         - CS_CHECK=true
     - php: 5.5
       env:
-        - SERVICE_MANAGER_VERSION="^2.7.5"
+        - DEPS=locked
+        - CS_CHECK=true
+    - php: 5.5
+      env:
+        - DEPS=latest
     - php: 5.6
       env:
+        - DEPS=lowest
+    - php: 5.6
+      env:
+        - DEPS=locked
         - TEST_COVERAGE=true
         - DEPLOY_DOCS="$(if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then echo -n 'true' ; else echo -n 'false' ; fi)"
         - PATH="$HOME/.local/bin:$PATH"
     - php: 5.6
       env:
-        - SERVICE_MANAGER_VERSION="^2.7.5"
-    - php: 7
+        - DEPS=latest
     - php: 7
       env:
-        - SERVICE_MANAGER_VERSION="^2.7.5"
-    - php: hhvm
+        - DEPS=lowest
+    - php: 7
+      env:
+        - DEPS=locked
+    - php: 7
+      env:
+        - DEPS=latest
+    - php: 7.1
+      env:
+        - DEPS=lowest
+    - php: 7.1
+      env:
+        - DEPS=locked
+    - php: 7.1
+      env:
+        - DEPS=latest
     - php: hhvm
       env:
-        - SERVICE_MANAGER_VERSION="^2.7.5"
+        - DEPS=lowest
+    - php: hhvm
+      env:
+        - DEPS=locked
+    - php: hhvm
+      env:
+        - DEPS=latest
   allow_failures:
     - php: hhvm
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
-  - composer self-update
-  - if [[ $TEST_COVERAGE == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
-  - composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION"
+  - travis_retry composer self-update
 
 install:
-  - travis_retry composer install --no-interaction --ignore-platform-reqs
+  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
+  - if [[ $TRAVIS_PHP_VERSION =~ ^5 ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
+  - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
+  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
+  - composer show
 
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi
@@ -72,11 +106,6 @@ after_script:
 
 notifications:
   email: false
-  irc:
-    channels:
-      - "irc.freenode.org#zftalk.dev"
-    on_success: change
-    on_failure: always
   slack:
     rooms:
       - secure: "aqczxxE4+LS3YLt2+WeBwSC26i/q77E0RFQJ8QMlEsZSDucdbMej8r6ntsf9HGevsFbl8qiWbJvTLbKR0yBDcFZF3qnhQ+rayto4jQAUA9u2EAXuZXIJqLvzoBDSXo33DisThM9PMpMeXHQ+1+8VXBW7XYkkIsBF+CMmJpIHax+cv4eeJuxvdA6V095o/xHKbtF4SMaBn+N9rRn24rTq9UVmsbn2eIRgW51PZGQv2ZJcbOmCOdNVEfdA6+q+xSPsS4iEMUW4U48xPoMpBzegfSJFjUsvFLUMf0AidscdDHpVxMlk0HxXI9EG1AY7SeOlkMFamvYMVKxapKq+piI9J6JRNeF+qu8/HwxRcu/WD0UrQ6hGBYhOkpMYoTswnuUfbI6TtTNKHXAS8NcefQPB8GiwgCarhtP2k0VQXEfRfLhMmOeJixaHXvqnStgqOh2nyMJAMKzv6eKkwYJJGQEgej41CjpSsuVxiU2h1MTaml8y6d7ym7Us1Sobgs0iEqxKTJc0EUzLNKdMJGrGQJZ6Pe2KlCIrA+PyQxx6W+BlBtd/Hdl0Tc0V07FSBJROQrBLQ680nb31p5M9MQbk34NGFfepvvjJpHzJ1tuOJn/7A/r2vNmDsqg1eNaTdezlQTNnDDkv52n/IsLQJvUMaQDR/Lw8n1kEpQc5GBFuGWFO/L4="

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
     },
     "require-dev": {
         "zendframework/zend-config": "^2.6",
-        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+        "zendframework/zend-servicemanager": "^2.7.8 || ^3.0.3",
         "zendframework/zend-crypt": "^2.6",
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^6.0.8 || ^5.7.15",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "suggest": {
@@ -43,6 +43,9 @@
         }
     },
     "autoload-dev": {
+        "files": [
+            "test/autoload.php"
+        ],
         "psr-4": {
             "ZendTest\\Mail\\": "test/"
         }

--- a/test/AddressListTest.php
+++ b/test/AddressListTest.php
@@ -9,14 +9,14 @@
 
 namespace ZendTest\Mail;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Address;
 use Zend\Mail\AddressList;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\AddressList<extended>
  */
-class AddressListTest extends \PHPUnit_Framework_TestCase
+class AddressListTest extends TestCase
 {
     public function setUp()
     {

--- a/test/AddressTest.php
+++ b/test/AddressTest.php
@@ -9,12 +9,14 @@
 
 namespace ZendTest\Mail;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Address;
+use Zend\Mail\Exception;
 
 /**
  * @covers Zend\Mail\Address<extended>
  */
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
     public function testDoesNotRequireNameForInstantiation()
     {
@@ -44,7 +46,7 @@ class AddressTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetAddressInvalidAddressObject($email, $name)
     {
-        $this->setExpectedException('Zend\Mail\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         new Address($email, $name);
     }
 

--- a/test/Header/AddressListHeaderTest.php
+++ b/test/Header/AddressListHeaderTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Mail\Header;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Address;
 use Zend\Mail\AddressList;
 use Zend\Mail\Header\Bcc;
@@ -17,10 +18,7 @@ use Zend\Mail\Header\From;
 use Zend\Mail\Header\ReplyTo;
 use Zend\Mail\Header\To;
 
-/**
- * @group      Zend_Mail
- */
-class AddressListHeaderTest extends \PHPUnit_Framework_TestCase
+class AddressListHeaderTest extends TestCase
 {
     public static function getHeaderInstances()
     {

--- a/test/Header/ContentTransferEncodingTest.php
+++ b/test/Header/ContentTransferEncodingTest.php
@@ -9,13 +9,14 @@
 
 namespace ZendTest\Mail\Header;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Header\ContentTransferEncoding;
+use Zend\Mail\Header\Exception;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Header\ContentTransferEncoding<extended>
  */
-class ContentTransferEncodingTest extends \PHPUnit_Framework_TestCase
+class ContentTransferEncodingTest extends TestCase
 {
     public function dataValidEncodings()
     {
@@ -50,7 +51,7 @@ class ContentTransferEncodingTest extends \PHPUnit_Framework_TestCase
      */
     public function testContentTransferEncodingFromStringRaisesException($encoding)
     {
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         $contentTransferEncodingHeader = ContentTransferEncoding::fromString('Content-Transfer-Encoding: '.$encoding);
     }
 
@@ -104,7 +105,7 @@ class ContentTransferEncodingTest extends \PHPUnit_Framework_TestCase
      */
     public function testFromStringRaisesExceptionOnInvalidHeaderName()
     {
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         ContentTransferEncoding::fromString('Content-Transfer-Encoding' . chr(32) . ': 8bit');
     }
 
@@ -124,7 +125,7 @@ class ContentTransferEncodingTest extends \PHPUnit_Framework_TestCase
      */
     public function testFromStringRaisesExceptionForInvalidMultilineValues($headerLine)
     {
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         ContentTransferEncoding::fromString($headerLine);
     }
 
@@ -133,7 +134,8 @@ class ContentTransferEncodingTest extends \PHPUnit_Framework_TestCase
      */
     public function testFromStringRaisesExceptionForContinuations()
     {
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException', 'expects');
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('expects');
         ContentTransferEncoding::fromString("Content-Transfer-Encoding: 8bit\r\n 7bit");
     }
 
@@ -143,7 +145,8 @@ class ContentTransferEncodingTest extends \PHPUnit_Framework_TestCase
     public function testSetTransferEncodingRaisesExceptionForInvalidValues()
     {
         $header = new ContentTransferEncoding();
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException', 'expects');
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('expects');
         $header->setTransferEncoding("8bit\r\n 7bit");
     }
 }

--- a/test/Header/ContentTypeTest.php
+++ b/test/Header/ContentTypeTest.php
@@ -9,16 +9,16 @@
 
 namespace ZendTest\Mail\Header;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Header\ContentType;
 use Zend\Mail\Header\Exception\InvalidArgumentException;
 use Zend\Mail\Header\HeaderInterface;
 use Zend\Mail\Header\UnstructuredInterface;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Header\ContentType<extended>
  */
-class ContentTypeTest extends \PHPUnit_Framework_TestCase
+class ContentTypeTest extends TestCase
 {
     public function testImplementsHeaderInterface()
     {
@@ -85,7 +85,8 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
      */
     public function testFromStringThrowException($headerLine, $expectedException, $exceptionMessage)
     {
-        $this->setExpectedException($expectedException, $exceptionMessage);
+        $this->expectException($expectedException);
+        $this->expectExceptionMessage($exceptionMessage);
         ContentType::fromString($headerLine);
     }
 
@@ -107,7 +108,8 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
         $header = new ContentType();
         $header->setType('text/html');
 
-        $this->setExpectedException($expectedException, $exceptionMessage);
+        $this->expectException($expectedException);
+        $this->expectExceptionMessage($exceptionMessage);
         $header->addParameter($paramName, $paramValue);
     }
 

--- a/test/Header/DateTest.php
+++ b/test/Header/DateTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\Mail\Header;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Header;
 
 /**
@@ -33,7 +33,7 @@ class DateTest extends TestCase
      */
     public function testFromStringRaisesExceptionOnCrlfInjectionAttempt($header)
     {
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
+        $this->expectException(Header\Exception\InvalidArgumentException::class);
         Header\Date::fromString($header);
     }
 
@@ -42,7 +42,7 @@ class DateTest extends TestCase
      */
     public function testPreventsCRLFInjectionViaConstructor()
     {
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
+        $this->expectException(Header\Exception\InvalidArgumentException::class);
         $address = new Header\Date("This\ris\r\na\nCRLF Attack");
     }
 }

--- a/test/Header/GenericHeaderTest.php
+++ b/test/Header/GenericHeaderTest.php
@@ -9,7 +9,8 @@
 
 namespace ZendTest\Mail\Header;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
+use Zend\Mail\Header\Exception;
 use Zend\Mail\Header\GenericHeader;
 
 /**
@@ -22,7 +23,7 @@ class GenericHeaderTest extends TestCase
      */
     public function testSplitHeaderLineRaisesExceptionOnInvalidHeader()
     {
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         GenericHeader::splitHeaderLine(
             'Content-Type' . chr(32) . ': text/html; charset = "iso-8859-1"' . "\nThis is a test"
         );
@@ -43,7 +44,8 @@ class GenericHeaderTest extends TestCase
     public function testRaisesExceptionOnInvalidFieldName($fieldName)
     {
         $header = new GenericHeader();
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException', 'name');
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('name');
         $header->setFieldName($fieldName);
     }
 

--- a/test/Header/HeaderNameTest.php
+++ b/test/Header/HeaderNameTest.php
@@ -9,7 +9,8 @@
 
 namespace ZendTest\Mail\Header;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
+use Zend\Mail\Header\Exception;
 use Zend\Mail\Header\HeaderName;
 
 /**
@@ -80,7 +81,8 @@ class HeaderNameTest extends TestCase
      */
     public function testAssertValidRaisesExceptionForInvalidNames($name)
     {
-        $this->setExpectedException('Zend\Mail\Header\Exception\RuntimeException', 'Invalid');
+        $this->expectException(Exception\RuntimeException::class);
+        $this->expectExceptionMessage('Invalid');
         HeaderName::assertValid($name);
     }
 }

--- a/test/Header/HeaderValueTest.php
+++ b/test/Header/HeaderValueTest.php
@@ -9,8 +9,9 @@
 
 namespace ZendTest\Mail\Header;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use Zend\Mail\Header\Exception;
 use Zend\Mail\Header\HeaderValue;
 
 /**
@@ -101,7 +102,8 @@ class HeaderValueTest extends TestCase
      */
     public function testAssertValidRaisesExceptionForInvalidValues($value)
     {
-        $this->setExpectedException('Zend\Mail\Header\Exception\RuntimeException', 'Invalid');
+        $this->expectException(Exception\RuntimeException::class);
+        $this->expectExceptionMessage('Invalid');
         HeaderValue::assertValid($value);
     }
 }

--- a/test/Header/HeaderWrapTest.php
+++ b/test/Header/HeaderWrapTest.php
@@ -9,19 +9,19 @@
 
 namespace ZendTest\Mail\Header;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Header\GenericHeader;
 use Zend\Mail\Header\HeaderWrap;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Header\HeaderWrap<extended>
  */
-class HeaderWrapTest extends \PHPUnit_Framework_TestCase
+class HeaderWrapTest extends TestCase
 {
     public function testWrapUnstructuredHeaderAscii()
     {
         $string = str_repeat('foobarblahblahblah baz bat', 4);
-        $header = $this->getMock('Zend\Mail\Header\UnstructuredInterface');
+        $header = $this->getMockBuilder('Zend\Mail\Header\UnstructuredInterface')->getMock();
         $header->expects($this->any())
             ->method('getEncoding')
             ->will($this->returnValue('ASCII'));
@@ -37,7 +37,7 @@ class HeaderWrapTest extends \PHPUnit_Framework_TestCase
     public function testWrapUnstructuredHeaderMime()
     {
         $string = str_repeat('foobarblahblahblah baz bat', 3);
-        $header = $this->getMock('Zend\Mail\Header\UnstructuredInterface');
+        $header = $this->getMockBuilder('Zend\Mail\Header\UnstructuredInterface')->getMock();
         $header->expects($this->any())
             ->method('getEncoding')
             ->will($this->returnValue('UTF-8'));

--- a/test/Header/MessageIdTest.php
+++ b/test/Header/MessageIdTest.php
@@ -9,13 +9,13 @@
 
 namespace ZendTest\Mail\Header;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Header;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Header\MessageId<extended>
  */
-class MessageIdTest extends \PHPUnit_Framework_TestCase
+class MessageIdTest extends TestCase
 {
     public function testSettingManually()
     {
@@ -52,7 +52,7 @@ class MessageIdTest extends \PHPUnit_Framework_TestCase
      */
     public function testFromStringPreventsCrlfInjectionOnDetection($header)
     {
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
+        $this->expectException(Header\Exception\InvalidArgumentException::class);
         $messageid = Header\MessageId::fromString($header);
     }
 
@@ -74,7 +74,7 @@ class MessageIdTest extends \PHPUnit_Framework_TestCase
     public function testInvalidIdentifierRaisesException($id)
     {
         $header = new Header\MessageId();
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
+        $this->expectException(Header\Exception\InvalidArgumentException::class);
         $header->setId($id);
     }
 }

--- a/test/Header/MimeVersionTest.php
+++ b/test/Header/MimeVersionTest.php
@@ -9,13 +9,13 @@
 
 namespace ZendTest\Mail\Header;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Header;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Header\MimeVersion<extended>
  */
-class MimeVersionTest extends \PHPUnit_Framework_TestCase
+class MimeVersionTest extends TestCase
 {
     public function testSettingManually()
     {
@@ -47,7 +47,7 @@ class MimeVersionTest extends \PHPUnit_Framework_TestCase
      */
     public function testFromStringRaisesExceptionOnDetectionOfCrlfInjection($header)
     {
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
+        $this->expectException(Header\Exception\InvalidArgumentException::class);
         $mime = Header\MimeVersion::fromString($header);
     }
 
@@ -68,7 +68,7 @@ class MimeVersionTest extends \PHPUnit_Framework_TestCase
     public function testRaisesExceptionOnInvalidVersionFromSetVersion($value)
     {
         $header = new Header\MimeVersion();
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
+        $this->expectException(Header\Exception\InvalidArgumentException::class);
         $header->setVersion($value);
     }
 }

--- a/test/Header/ReceivedTest.php
+++ b/test/Header/ReceivedTest.php
@@ -9,13 +9,13 @@
 
 namespace ZendTest\Mail\Header;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Header;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Header\Received<extended>
  */
-class ReceivedTest extends \PHPUnit_Framework_TestCase
+class ReceivedTest extends TestCase
 {
     public function testFromStringCreatesValidReceivedHeader()
     {
@@ -67,7 +67,7 @@ class ReceivedTest extends \PHPUnit_Framework_TestCase
      */
     public function testRaisesExceptionViaFromStringOnDetectionOfCrlfInjection($header)
     {
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
+        $this->expectException(Header\Exception\InvalidArgumentException::class);
         $received = Header\Received::fromString($header);
     }
 
@@ -87,7 +87,7 @@ class ReceivedTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorRaisesExceptionOnValueWithCRLFInjectionAttempt($value)
     {
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
+        $this->expectException(Header\Exception\InvalidArgumentException::class);
         new Header\Received($value);
     }
 }

--- a/test/Header/SenderTest.php
+++ b/test/Header/SenderTest.php
@@ -9,15 +9,15 @@
 
 namespace ZendTest\Mail\Header;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Address;
-use Zend\Mail\Header;
 use Zend\Mail\Exception;
+use Zend\Mail\Header;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Header\Sender<extended>
  */
-class SenderTest extends \PHPUnit_Framework_TestCase
+class SenderTest extends TestCase
 {
     public function testFromStringCreatesValidReceivedHeader()
     {
@@ -61,7 +61,10 @@ class SenderTest extends \PHPUnit_Framework_TestCase
         $expectedException,
         $expectedExceptionMessage
     ) {
-        $this->setExpectedException($expectedException, $expectedExceptionMessage);
+        $this->expectException($expectedException);
+        if (! empty($expectedExceptionMessage)) {
+            $this->expectExceptionMessage($expectedExceptionMessage);
+        }
         Header\Sender::fromString('Sender:' . $decodedValue);
     }
 
@@ -93,7 +96,7 @@ class SenderTest extends \PHPUnit_Framework_TestCase
     public function testSetAddressInvalidValue($email, $name)
     {
         $header = new Header\Sender();
-        $this->setExpectedException('Zend\Mail\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         $header->setAddress($email, $name);
     }
 
@@ -247,7 +250,8 @@ class SenderTest extends \PHPUnit_Framework_TestCase
      */
     public function testFromStringWithInvalidInput($headerString, $expectedException, $expectedMessagePart = '')
     {
-        $this->setExpectedException($expectedException, $expectedMessagePart);
+        $this->expectException($expectedException);
+        $this->expectExceptionMessage($expectedMessagePart);
 
         Header\Sender::fromString($headerString);
     }

--- a/test/Header/SubjectTest.php
+++ b/test/Header/SubjectTest.php
@@ -9,13 +9,13 @@
 
 namespace ZendTest\Mail\Header;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Header;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Header\Subject<extended>
  */
-class SubjectTest extends \PHPUnit_Framework_TestCase
+class SubjectTest extends TestCase
 {
     public function testHeaderFolding()
     {
@@ -55,7 +55,8 @@ class SubjectTest extends \PHPUnit_Framework_TestCase
         $expectedException,
         $expectedExceptionMessage
     ) {
-        $this->setExpectedException($expectedException, $expectedExceptionMessage);
+        $this->expectException($expectedException);
+        $this->expectExceptionMessage($expectedExceptionMessage);
         Header\Subject::fromString('Subject:' . $decodedValue);
     }
 

--- a/test/Header/ToTest.php
+++ b/test/Header/ToTest.php
@@ -9,16 +9,16 @@
 
 namespace ZendTest\Mail\Header;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Header;
 
 /**
  * This test is primarily to test that AbstractAddressList headers perform
  * header folding and MIME encoding properly.
  *
- * @group      Zend_Mail
  * @covers Zend\Mail\Header\To<extended>
  */
-class ToTest extends \PHPUnit_Framework_TestCase
+class ToTest extends TestCase
 {
     public function testHeaderFoldingOccursProperly()
     {
@@ -48,7 +48,7 @@ class ToTest extends \PHPUnit_Framework_TestCase
      */
     public function testFromStringRaisesExceptionWhenCrlfInjectionIsDetected($header)
     {
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
+        $this->expectException(Header\Exception\InvalidArgumentException::class);
         Header\To::fromString($header);
     }
 }

--- a/test/HeadersTest.php
+++ b/test/HeadersTest.php
@@ -9,14 +9,15 @@
 
 namespace ZendTest\Mail;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail;
+use Zend\Mail\Exception;
 use Zend\Mail\Header;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Headers<extended>
  */
-class HeadersTest extends \PHPUnit_Framework_TestCase
+class HeadersTest extends TestCase
 {
     public function testHeadersImplementsProperClasses()
     {
@@ -74,7 +75,8 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
 
     public function testHeadersFromStringFactoryThrowsExceptionOnMalformedHeaderLine()
     {
-        $this->setExpectedException('Zend\Mail\Exception\RuntimeException', 'does not match');
+        $this->expectException(Exception\RuntimeException::class);
+        $this->expectExceptionMessage('does not match');
         Mail\Headers::fromString("Fake = foo-bar\r\n\r\n");
     }
 
@@ -145,10 +147,8 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
 
     public function testHeadersAddHeaderLineThrowsExceptionOnMissingFieldValue()
     {
-        $this->setExpectedException(
-            'Zend\Mail\Header\Exception\InvalidArgumentException',
-            'Header must match with the format "name:value"'
-        );
+        $this->expectException(Header\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Header must match with the format "name:value"');
         $headers = new Mail\Headers();
         $headers->addHeaderLine('Foo');
     }
@@ -193,7 +193,8 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
 
     public function testHeadersAddHeadersThrowsExceptionOnInvalidArguments()
     {
-        $this->setExpectedException('Zend\Mail\Exception\InvalidArgumentException', 'Expected array or Trav');
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected array or Trav');
         $headers = new Mail\Headers();
         $headers->addHeaders('foo');
     }
@@ -405,7 +406,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
      */
     public function testHeaderCrLfAttackFromString()
     {
-        $this->setExpectedException('Zend\Mail\Exception\RuntimeException');
+        $this->expectException(Exception\RuntimeException::class);
         Mail\Headers::fromString("Fake: foo-bar\r\n\r\nevilContent");
     }
 
@@ -415,7 +416,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
     public function testHeaderCrLfAttackAddHeaderLineSingle()
     {
         $headers = new Mail\Headers();
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         $headers->addHeaderLine("Fake: foo-bar\r\n\r\nevilContent");
     }
 
@@ -425,7 +426,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
     public function testHeaderCrLfAttackAddHeaderLineWithValue()
     {
         $headers = new Mail\Headers();
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
+        $this->expectException(Header\Exception\InvalidArgumentException::class);
         $headers->addHeaderLine('Fake', "foo-bar\r\n\r\nevilContent");
     }
 
@@ -435,7 +436,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
     public function testHeaderCrLfAttackAddHeaderLineMultiple()
     {
         $headers = new Mail\Headers();
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
+        $this->expectException(Header\Exception\InvalidArgumentException::class);
         $headers->addHeaderLine('Fake', ["foo-bar\r\n\r\nevilContent"]);
         $headers->forceLoading();
     }
@@ -446,7 +447,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
     public function testHeaderCrLfAttackAddHeadersSingle()
     {
         $headers = new Mail\Headers();
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
+        $this->expectException(Header\Exception\InvalidArgumentException::class);
         $headers->addHeaders(["Fake: foo-bar\r\n\r\nevilContent"]);
     }
 
@@ -456,7 +457,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
     public function testHeaderCrLfAttackAddHeadersWithValue()
     {
         $headers = new Mail\Headers();
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
+        $this->expectException(Header\Exception\InvalidArgumentException::class);
         $headers->addHeaders(['Fake' => "foo-bar\r\n\r\nevilContent"]);
     }
 
@@ -466,7 +467,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
     public function testHeaderCrLfAttackAddHeadersMultiple()
     {
         $headers = new Mail\Headers();
-        $this->setExpectedException('Zend\Mail\Header\Exception\InvalidArgumentException');
+        $this->expectException(Header\Exception\InvalidArgumentException::class);
         $headers->addHeaders(['Fake' => ["foo-bar\r\n\r\nevilContent"]]);
         $headers->forceLoading();
     }

--- a/test/MessageFactoryTest.php
+++ b/test/MessageFactoryTest.php
@@ -9,13 +9,14 @@
 
 namespace ZendTest\Mail;
 
+use PHPUnit\Framework\TestCase;
+use Zend\Mail\Exception;
 use Zend\Mail\MessageFactory;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\MessageFactory<extended>
  */
-class MessageFactoryTest extends \PHPUnit_Framework_TestCase
+class MessageFactoryTest extends TestCase
 {
     public function testConstructMessageWithOptions()
     {
@@ -117,7 +118,7 @@ class MessageFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testExceptionForOptionsNotArrayOrTraversable($options)
     {
-        $this->setExpectedException('Zend\Mail\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         MessageFactory::getInstance($options);
     }
 }

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -9,9 +9,11 @@
 
 namespace ZendTest\Mail;
 
+use PHPUnit\Framework\TestCase;
 use stdClass;
 use Zend\Mail\Address;
 use Zend\Mail\AddressList;
+use Zend\Mail\Exception;
 use Zend\Mail\Header;
 use Zend\Mail\Headers;
 use Zend\Mail\Message;
@@ -20,10 +22,9 @@ use Zend\Mime\Mime;
 use Zend\Mime\Part as MimePart;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Message<extended>
  */
-class MessageTest extends \PHPUnit_Framework_TestCase
+class MessageTest extends TestCase
 {
     /** @var Message */
     public $message;
@@ -532,7 +533,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
      */
     public function testSettingNonScalarNonMimeNonStringSerializableValueForBodyRaisesException($body)
     {
-        $this->setExpectedException('Zend\Mail\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         $this->message->setBody($body);
     }
 
@@ -757,7 +758,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
             '',
             '<html><body><iframe src="http://example.com/"></iframe></body></html> <!--',
         ];
-        $this->setExpectedException('Zend\Mail\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         $this->message->{$recipientMethod}(implode(Headers::EOL, $subject));
     }
 

--- a/test/Protocol/ProtocolTraitTest.php
+++ b/test/Protocol/ProtocolTraitTest.php
@@ -9,13 +9,13 @@
 
 namespace ZendTest\Mail\Protocol;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Protocol\ProtocolTrait;
 
 /**
- * @group   Zend_Mail
  * @covers  Zend\Mail\Protocol\ProtocolTrait
  */
-class ProtocolTraitTest extends \PHPUnit_Framework_TestCase
+class ProtocolTraitTest extends TestCase
 {
     /**
      * @requires PHP 5.6.7

--- a/test/Protocol/Smtp/Auth/Crammd5Test.php
+++ b/test/Protocol/Smtp/Auth/Crammd5Test.php
@@ -9,14 +9,14 @@
 
 namespace ZendTest\Mail\Protocol\Smtp\Auth;
 
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Zend\Mail\Protocol\Smtp\Auth\Crammd5;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Protocol\Smtp\Auth\Crammd5<extended>
  */
-class Crammd5Test extends \PHPUnit_Framework_TestCase
+class Crammd5Test extends TestCase
 {
     /**
      * @var Crammd5

--- a/test/Protocol/SmtpPluginManagerCompatibilityTest.php
+++ b/test/Protocol/SmtpPluginManagerCompatibilityTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\Mail\Protocol;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Protocol\Smtp;
 use Zend\Mail\Protocol\SmtpPluginManager;
 use Zend\Mail\Protocol\Exception\InvalidArgumentException;

--- a/test/Protocol/SmtpPluginManagerFactoryTest.php
+++ b/test/Protocol/SmtpPluginManagerFactoryTest.php
@@ -8,7 +8,7 @@
 namespace ZendTest\Mail\Protocol;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Protocol\Smtp;
 use Zend\Mail\Protocol\SmtpPluginManager;
 use Zend\Mail\Protocol\SmtpPluginManagerFactory;

--- a/test/Protocol/SmtpTest.php
+++ b/test/Protocol/SmtpTest.php
@@ -9,16 +9,17 @@
 
 namespace ZendTest\Mail\Protocol;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Headers;
 use Zend\Mail\Message;
+use Zend\Mail\Protocol\Exception;
 use Zend\Mail\Transport\Smtp;
 use ZendTest\Mail\TestAsset\SmtpProtocolSpy;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Protocol\Smtp<extended>
  */
-class SmtpTest extends \PHPUnit_Framework_TestCase
+class SmtpTest extends TestCase
 {
     /** @var Smtp */
     public $transport;
@@ -107,7 +108,8 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
     {
         $smtp = new TestAsset\ErroneousSmtp();
 
-        $this->setExpectedExceptionRegExp('Zend\Mail\Protocol\Exception\RuntimeException', '/nonexistentremote/');
+        $this->expectException(Exception\RuntimeException::class);
+        $this->expectExceptionMessageRegExp('/nonexistentremote/');
 
         $smtp->connect('nonexistentremote');
     }

--- a/test/Storage/ImapTest.php
+++ b/test/Storage/ImapTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Mail\Storage;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Config;
 use Zend\Mail\Protocol;
 use Zend\Mail\Storage;
@@ -16,7 +17,7 @@ use Zend\Mail\Storage;
 /**
  * @covers Zend\Mail\Storage\Imap<extended>
  */
-class ImapTest extends \PHPUnit_Framework_TestCase
+class ImapTest extends TestCase
 {
     protected $params;
 
@@ -98,13 +99,13 @@ class ImapTest extends \PHPUnit_Framework_TestCase
     public function testConnectFailure()
     {
         $this->params['host'] = 'example.example';
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         new Storage\Imap($this->params);
     }
 
     public function testNoParams()
     {
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         new Storage\Imap([]);
     }
 
@@ -132,14 +133,14 @@ class ImapTest extends \PHPUnit_Framework_TestCase
     public function testInvalidService()
     {
         $this->params['port'] = getenv('TESTS_ZEND_MAIL_IMAP_INVALID_PORT');
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         new Storage\Imap($this->params);
     }
 
     public function testWrongService()
     {
         $this->params['port'] = getenv('TESTS_ZEND_MAIL_IMAP_WRONG_PORT');
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         new Storage\Imap($this->params);
     }
 
@@ -147,7 +148,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
     {
         // this also triggers ...{chars}<NL>token for coverage
         $this->params['user'] = "there is no\nnobody";
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         new Storage\Imap($this->params);
     }
 
@@ -162,14 +163,14 @@ class ImapTest extends \PHPUnit_Framework_TestCase
     public function testWithNotConnectedInstance()
     {
         $protocol = new Protocol\Imap();
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         new Storage\Imap($protocol);
     }
 
     public function testWithNotLoggedInstance()
     {
         $protocol = new Protocol\Imap($this->params['host']);
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         new Storage\Imap($protocol);
     }
 
@@ -177,7 +178,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
     {
         $this->params['folder'] = 'this folder does not exist on your server';
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         new Storage\Imap($this->params);
     }
 
@@ -287,14 +288,14 @@ class ImapTest extends \PHPUnit_Framework_TestCase
         $mail->close();
         // after closing we can't count messages
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->countMessages();
     }
 
     public function testLoadUnkownFolder()
     {
         $this->params['folder'] = 'UnknownFolder';
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         new Storage\Imap($this->params);
     }
 
@@ -309,7 +310,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
     public function testUnknownFolder()
     {
         $mail = new Storage\Imap($this->params);
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->selectFolder('/Unknown/Folder/');
     }
 
@@ -435,7 +436,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
     public function testWrongUniqueId()
     {
         $mail = new Storage\Imap($this->params);
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->getNumberByUniqueId('this_is_an_invalid_id');
     }
 
@@ -455,7 +456,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
     {
         $mail = new Storage\Imap($this->params);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->createFolder('subfolder/test');
     }
 
@@ -464,7 +465,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
         $mail = new Storage\Imap($this->params);
         $mail->removeFolder('subfolder/test');
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->getFolders()->subfolder->test;
     }
 
@@ -473,7 +474,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
         $mail = new Storage\Imap($this->params);
         $mail->removeFolder($mail->getFolders()->subfolder->test);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->getFolders()->subfolder->test;
     }
 
@@ -481,7 +482,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
     {
         $mail = new Storage\Imap($this->params);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->removeFolder('thisFolderDoestNotExist');
     }
 
@@ -492,7 +493,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
         $mail->renameFolder('subfolder/test', 'subfolder/test1');
         $mail->renameFolder($mail->getFolders()->subfolder->test1, 'subfolder/test');
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->renameFolder('subfolder/test', 'INBOX');
     }
 
@@ -512,7 +513,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($count + 1, $mail->countMessages());
         $this->assertEquals($mail->getMessage($count + 1)->subject, 'append test');
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->appendMessage('');
     }
 
@@ -532,7 +533,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($mail->getMessage($count + 1)->from, $message->from);
         $this->assertEquals($mail->getMessage($count + 1)->to, $message->to);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->copyMessage(1, 'justARandomFolder');
     }
 
@@ -561,7 +562,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($message->hasFlag(Storage::FLAG_FLAGGED));
         $this->assertTrue($message->hasFlag('myflag'));
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->setFlags(1, [Storage::FLAG_RECENT]);
     }
 
@@ -610,7 +611,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
         $protocol->login($this->params['user'], $this->params['password']);
         $protocol->logout();
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $protocol->select("foo\nbar");
     }
 
@@ -645,7 +646,7 @@ class ImapTest extends \PHPUnit_Framework_TestCase
             $this->assertInternalType('array', $v['FLAGS']);
         }
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $protocol->fetch('UID', 99);
     }
 

--- a/test/Storage/MaildirFolderTest.php
+++ b/test/Storage/MaildirFolderTest.php
@@ -9,14 +9,13 @@
 
 namespace ZendTest\Mail\Storage;
 
+use PHPUnit\Framework\TestCase;
 use RecursiveIteratorIterator;
 use Zend\Config;
+use Zend\Mail\Storage\Exception;
 use Zend\Mail\Storage\Folder;
 
-/**
- * @group      Zend_Mail
- */
-class MaildirFolderTest extends \PHPUnit_Framework_TestCase
+class MaildirFolderTest extends TestCase
 {
     protected $params;
     protected $originalDir;
@@ -118,20 +117,20 @@ class MaildirFolderTest extends \PHPUnit_Framework_TestCase
 
     public function testNoParams()
     {
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         new Folder\Maildir([]);
     }
 
     public function testLoadFailure()
     {
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         new Folder\Maildir(['dirname' => 'This/Folder/Does/Not/Exist']);
     }
 
     public function testLoadUnkownFolder()
     {
         $this->params['folder'] = 'UnknownFolder';
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         new Folder\Maildir($this->params);
     }
 
@@ -149,7 +148,7 @@ class MaildirFolderTest extends \PHPUnit_Framework_TestCase
     {
         $mail = new Folder\Maildir($this->params);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         $mail->selectFolder('/Unknown/Folder/');
     }
 
@@ -355,7 +354,7 @@ class MaildirFolderTest extends \PHPUnit_Framework_TestCase
         $root = $mail->getFolders();
         $root->foobar = new Folder('foobar', DIRECTORY_SEPARATOR . 'foobar');
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         $mail->selectFolder('foobar');
     }
 
@@ -365,7 +364,7 @@ class MaildirFolderTest extends \PHPUnit_Framework_TestCase
         $root = $mail->getFolders();
         $root->foobar = new Folder('foobar', 'foobar');
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         $mail->selectFolder('foobar');
     }
 
@@ -375,7 +374,7 @@ class MaildirFolderTest extends \PHPUnit_Framework_TestCase
         $root = $mail->getFolders();
         $root->foobar = new Folder('foobar', 'foobar', false);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         $mail->selectFolder('foobar');
     }
 

--- a/test/Storage/MaildirMessageOldTest.php
+++ b/test/Storage/MaildirMessageOldTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\Mail\Storage;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Storage;
 
 class MaildirMessageOldTest extends TestCase

--- a/test/Storage/MaildirTest.php
+++ b/test/Storage/MaildirTest.php
@@ -9,13 +9,11 @@
 
 namespace ZendTest\Mail\Storage;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Config;
 use Zend\Mail\Storage;
 
-/**
- * @group      Zend_Mail
- */
-class MaildirTest extends \PHPUnit_Framework_TestCase
+class MaildirTest extends TestCase
 {
     protected $originalMaildir;
     protected $maildir;
@@ -98,13 +96,13 @@ class MaildirTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadFailure()
     {
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         new Storage\Maildir(['dirname' => '/This/Dir/Does/Not/Exist']);
     }
 
     public function testLoadInvalid()
     {
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         new Storage\Maildir(['dirname' => __DIR__]);
     }
 
@@ -200,7 +198,7 @@ class MaildirTest extends \PHPUnit_Framework_TestCase
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->getSize(0);
     }
 
@@ -208,7 +206,7 @@ class MaildirTest extends \PHPUnit_Framework_TestCase
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->getMessage(0);
     }
 
@@ -216,7 +214,7 @@ class MaildirTest extends \PHPUnit_Framework_TestCase
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->removeMessage(1);
     }
 
@@ -262,7 +260,7 @@ class MaildirTest extends \PHPUnit_Framework_TestCase
     {
         $mail = new Storage\Maildir(['dirname' => $this->maildir]);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->getNumberByUniqueId('this_is_an_invalid_id');
     }
 

--- a/test/Storage/MaildirWritableTest.php
+++ b/test/Storage/MaildirWritableTest.php
@@ -9,14 +9,12 @@
 
 namespace ZendTest\Mail\Storage;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail;
 use Zend\Mail\Storage;
 use Zend\Mail\Storage\Writable;
 
-/**
- * @group      Zend_Mail
- */
-class MaildirWritableTest extends \PHPUnit_Framework_TestCase
+class MaildirWritableTest extends TestCase
 {
     protected $params;
     protected $originalDir;
@@ -133,21 +131,21 @@ class MaildirWritableTest extends \PHPUnit_Framework_TestCase
     public function testCreateFolderEmptyPart()
     {
         $mail = new Writable\Maildir($this->params);
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->createFolder('foo..bar');
     }
 
     public function testCreateFolderSlash()
     {
         $mail = new Writable\Maildir($this->params);
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->createFolder('foo/bar');
     }
 
     public function testCreateFolderDirectorySeparator()
     {
         $mail = new Writable\Maildir($this->params);
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->createFolder('foo' . DIRECTORY_SEPARATOR . 'bar');
     }
 
@@ -157,7 +155,7 @@ class MaildirWritableTest extends \PHPUnit_Framework_TestCase
         $mail = new Writable\Maildir($this->params);
         unset($mail->getFolders()->subfolder->test);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->createFolder('subfolder.test');
     }
 
@@ -165,7 +163,7 @@ class MaildirWritableTest extends \PHPUnit_Framework_TestCase
     {
         $mail = new Writable\Maildir($this->params);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->createFolder('subfolder.test');
     }
 
@@ -175,7 +173,7 @@ class MaildirWritableTest extends \PHPUnit_Framework_TestCase
         $mail = new Writable\Maildir($this->params);
         $mail->removeFolder('INBOX.subfolder.test');
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->selectFolder($mail->getFolders()->subfolder->test);
     }
 
@@ -185,7 +183,7 @@ class MaildirWritableTest extends \PHPUnit_Framework_TestCase
         $mail = new Writable\Maildir($this->params);
         $mail->removeFolder($mail->getFolders()->subfolder->test);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->selectFolder($mail->getFolders()->subfolder->test);
     }
 
@@ -193,7 +191,7 @@ class MaildirWritableTest extends \PHPUnit_Framework_TestCase
     {
         $mail = new Writable\Maildir($this->params);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->removeFolder($mail->getFolders()->subfolder);
     }
 
@@ -203,7 +201,7 @@ class MaildirWritableTest extends \PHPUnit_Framework_TestCase
         $mail = new Writable\Maildir($this->params);
         $mail->selectFolder('subfolder.test');
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->removeFolder('subfolder.test');
     }
 
@@ -211,7 +209,7 @@ class MaildirWritableTest extends \PHPUnit_Framework_TestCase
     {
         $mail = new Writable\Maildir($this->params);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->removeFolder('thisFolderDoestNotExist');
     }
 
@@ -223,7 +221,7 @@ class MaildirWritableTest extends \PHPUnit_Framework_TestCase
         $mail->renameFolder('INBOX.subfolder', 'INBOX.foo');
         $mail->renameFolder($mail->getFolders()->foo, 'subfolder');
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->renameFolder('INBOX', 'foo');
     }
 
@@ -233,7 +231,7 @@ class MaildirWritableTest extends \PHPUnit_Framework_TestCase
         $mail = new Writable\Maildir($this->params);
         $mail->selectFolder('subfolder.test');
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->renameFolder('subfolder.test', 'foo');
     }
 
@@ -241,7 +239,7 @@ class MaildirWritableTest extends \PHPUnit_Framework_TestCase
     {
         $mail = new Writable\Maildir($this->params);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->renameFolder('subfolder.test', 'subfolder.test.foo');
     }
 
@@ -279,7 +277,7 @@ class MaildirWritableTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($mail->getMessage($count + 1)->from, $message->from);
         $this->assertEquals($mail->getMessage($count + 1)->to, $message->to);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->copyMessage(1, 'justARandomFolder');
     }
 
@@ -302,7 +300,7 @@ class MaildirWritableTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($message->hasFlag(Storage::FLAG_SEEN));
         $this->assertTrue($message->hasFlag(Storage::FLAG_FLAGGED));
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->setFlags(1, [Storage::FLAG_RECENT]);
     }
 
@@ -311,7 +309,7 @@ class MaildirWritableTest extends \PHPUnit_Framework_TestCase
         $mail = new Writable\Maildir($this->params);
         unlink($this->params['dirname'] . 'cur/1000000000.P1.example.org:2,S');
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
     }
 
     public function testRemove()
@@ -331,7 +329,7 @@ class MaildirWritableTest extends \PHPUnit_Framework_TestCase
         $mail = new Writable\Maildir($this->params);
         unlink($this->params['dirname'] . 'cur/1000000000.P1.example.org:2,S');
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->removeMessage(1);
     }
 
@@ -395,7 +393,7 @@ class MaildirWritableTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($mail->getQuota());
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->getQuota(true);
     }
 
@@ -447,7 +445,7 @@ class MaildirWritableTest extends \PHPUnit_Framework_TestCase
         $mail->setQuota(true);
         $this->assertTrue($mail->checkQuota());
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->appendMessage("Subject: test\r\n\r\n");
     }
 

--- a/test/Storage/MboxFolderTest.php
+++ b/test/Storage/MboxFolderTest.php
@@ -9,14 +9,13 @@
 
 namespace ZendTest\Mail\Storage;
 
+use PHPUnit\Framework\TestCase;
 use RecursiveIteratorIterator;
 use Zend\Config;
+use Zend\Mail\Storage\Exception;
 use Zend\Mail\Storage\Folder;
 
-/**
- * @group      Zend_Mail
- */
-class MboxFolderTest extends \PHPUnit_Framework_TestCase
+class MboxFolderTest extends TestCase
 {
     protected $params;
     protected $originalDir;
@@ -98,20 +97,20 @@ class MboxFolderTest extends \PHPUnit_Framework_TestCase
 
     public function testNoParams()
     {
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         new Folder\Mbox([]);
     }
 
     public function testFilenameParam()
     {
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         // filename is not allowed in this subclass
         new Folder\Mbox(['filename' => 'foobar']);
     }
 
     public function testLoadFailure()
     {
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         new Folder\Mbox(['dirname' => 'This/Folder/Does/Not/Exist']);
     }
 
@@ -119,7 +118,7 @@ class MboxFolderTest extends \PHPUnit_Framework_TestCase
     {
         $this->params['folder'] = 'UnknownFolder';
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         new Folder\Mbox($this->params);
     }
 
@@ -138,14 +137,14 @@ class MboxFolderTest extends \PHPUnit_Framework_TestCase
     public function testChangeFolderUnselectable()
     {
         $mail = new Folder\Mbox($this->params);
-        $this->setExpectedException('Zend\Mail\Storage\Exception\RuntimeException');
+        $this->expectException(Exception\RuntimeException::class);
         $mail->selectFolder(DIRECTORY_SEPARATOR . 'subfolder');
     }
 
     public function testUnknownFolder()
     {
         $mail = new Folder\Mbox($this->params);
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         $mail->selectFolder('/Unknown/Folder/');
     }
 
@@ -285,7 +284,7 @@ class MboxFolderTest extends \PHPUnit_Framework_TestCase
         touch($this->params['dirname'] . 'foobar');
         $mail = new Folder\Mbox($this->params);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         $mail->getFolders()->foobar;
     }
 
@@ -328,7 +327,7 @@ class MboxFolderTest extends \PHPUnit_Framework_TestCase
         $mail = new Folder\Mbox($this->params);
         $root = $mail->getFolders();
         $root->foobar = new Folder('x', 'x');
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         $mail->getFolders('foobar');
     }
 
@@ -338,7 +337,7 @@ class MboxFolderTest extends \PHPUnit_Framework_TestCase
         $root = $mail->getFolders();
         $root->foobar = new Folder('foobar', DIRECTORY_SEPARATOR . 'foobar');
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\RuntimeException');
+        $this->expectException(Exception\RuntimeException::class);
         $mail->selectFolder('foobar');
     }
 }

--- a/test/Storage/MboxInterfaceTest.php
+++ b/test/Storage/MboxInterfaceTest.php
@@ -9,15 +9,15 @@
 
 namespace ZendTest\Mail\Storage;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail;
 use Zend\Mail\Storage;
 use Zend\Mail\Storage\Message;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Storage\Mbox<extended>
  */
-class MboxInterfaceTest extends \PHPUnit_Framework_TestCase
+class MboxInterfaceTest extends TestCase
 {
     protected $mboxFile;
 
@@ -60,7 +60,7 @@ class MboxInterfaceTest extends \PHPUnit_Framework_TestCase
     {
         $list = new Storage\Mbox(['filename' => $this->mboxFile]);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\RuntimeException');
+        $this->expectException(Storage\Exception\RuntimeException::class);
         $list[1] = 'test';
     }
 
@@ -136,7 +136,7 @@ class MboxInterfaceTest extends \PHPUnit_Framework_TestCase
     {
         $list = new Storage\Mbox(['filename' => $this->mboxFile]);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $list->thisdoesnotexist;
     }
 
@@ -151,7 +151,7 @@ class MboxInterfaceTest extends \PHPUnit_Framework_TestCase
     {
         $list = new Storage\Mbox(['filename' => $this->mboxFile]);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $list[1]->thisdoesnotexist;
     }
 }

--- a/test/Storage/MboxMessageOldTest.php
+++ b/test/Storage/MboxMessageOldTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\Mail\Storage;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class MboxMessageOldTest extends TestCase
 {

--- a/test/Storage/MboxTest.php
+++ b/test/Storage/MboxTest.php
@@ -9,13 +9,11 @@
 
 namespace ZendTest\Mail\Storage;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Config;
 use Zend\Mail\Storage;
 
-/**
- * @group      Zend_Mail
- */
-class MboxTest extends \PHPUnit_Framework_TestCase
+class MboxTest extends TestCase
 {
     protected $mboxOriginalFile;
     protected $mboxFile;
@@ -72,19 +70,19 @@ class MboxTest extends \PHPUnit_Framework_TestCase
 
     public function testNoParams()
     {
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         new Storage\Mbox([]);
     }
 
     public function testLoadFailure()
     {
-        $this->setExpectedException('Zend\Mail\Storage\Exception\RuntimeException');
+        $this->expectException(Storage\Exception\RuntimeException::class);
         new Storage\Mbox(['filename' => 'ThisFileDoesNotExist']);
     }
 
     public function testLoadInvalid()
     {
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         new Storage\Mbox(['filename' => __FILE__]);
     }
 
@@ -204,7 +202,7 @@ class MboxTest extends \PHPUnit_Framework_TestCase
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\RuntimeException');
+        $this->expectException(Storage\Exception\RuntimeException::class);
         $mail->removeMessage(1);
     }
 
@@ -229,7 +227,7 @@ class MboxTest extends \PHPUnit_Framework_TestCase
     {
         $mail = new Storage\Mbox(['filename' => $this->mboxFile]);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\OutOfBoundsException');
+        $this->expectException(Storage\Exception\OutOfBoundsException::class);
         $mail->seek(INF);
     }
 

--- a/test/Storage/MessageTest.php
+++ b/test/Storage/MessageTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Mail\Storage;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Exception as MailException;
 use Zend\Mail\Storage;
 use Zend\Mail\Storage\Exception;
@@ -17,10 +18,9 @@ use Zend\Mime;
 use Zend\Mime\Exception as MimeException;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Storage\Message<extended>
  */
-class MessageTest extends \PHPUnit_Framework_TestCase
+class MessageTest extends TestCase
 {
     protected $file;
     protected $file2;
@@ -273,7 +273,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $message = new Message([]);
         $subject = null;
 
-        $this->setExpectedException('Zend\\Mail\\Exception\\InvalidArgumentException');
+        $this->expectException(MailException\InvalidArgumentException::class);
         $message->subject;
     }
 
@@ -431,7 +431,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
      */
     public function testStrictParseMessage()
     {
-        $this->setExpectedException('Zend\\Mail\\Exception\\RuntimeException');
+        $this->expectException(MailException\RuntimeException::class);
 
         $raw = file_get_contents($this->file);
         $raw = "From foo@example.com  Sun Jan 01 00:00:00 2000\n" . $raw;

--- a/test/Storage/Pop3Test.php
+++ b/test/Storage/Pop3Test.php
@@ -9,15 +9,15 @@
 
 namespace ZendTest\Mail\Storage;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Config;
 use Zend\Mail\Protocol;
 use Zend\Mail\Storage;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Storage\Pop3<extended>
  */
-class Pop3Test extends \PHPUnit_Framework_TestCase
+class Pop3Test extends TestCase
 {
     protected $params;
 
@@ -105,13 +105,13 @@ class Pop3Test extends \PHPUnit_Framework_TestCase
     {
         $this->params['host'] = 'example.example';
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         new Storage\Pop3($this->params);
     }
 
     public function testNoParams()
     {
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         new Storage\Pop3([]);
     }
 
@@ -141,7 +141,7 @@ class Pop3Test extends \PHPUnit_Framework_TestCase
     {
         $this->params['port'] = getenv('TESTS_ZEND_MAIL_POP3_INVALID_PORT');
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         new Storage\Pop3($this->params);
     }
 
@@ -149,7 +149,7 @@ class Pop3Test extends \PHPUnit_Framework_TestCase
     {
         $this->params['port'] = getenv('TESTS_ZEND_MAIL_POP3_WRONG_PORT');
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         new Storage\Pop3($this->params);
     }
 
@@ -262,7 +262,7 @@ class Pop3Test extends \PHPUnit_Framework_TestCase
         $protocol = new Protocol\Pop3($this->params['host']);
         $mail = new Storage\Pop3($protocol);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         // because we did no login this has to throw an exception
         $mail->getMessage(1);
     }
@@ -272,7 +272,7 @@ class Pop3Test extends \PHPUnit_Framework_TestCase
         $mail = new Storage\Pop3($this->params);
         $mail->close();
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->getMessage(1);
     }
 
@@ -328,7 +328,7 @@ class Pop3Test extends \PHPUnit_Framework_TestCase
     {
         $mail = new Storage\Pop3($this->params);
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $mail->getNumberByUniqueId('this_is_an_invalid_id');
     }
 
@@ -337,7 +337,7 @@ class Pop3Test extends \PHPUnit_Framework_TestCase
         $protocol = new Protocol\Pop3($this->params['host']);
         $protocol->logout();
 
-        $this->setExpectedException('Zend\Mail\Storage\Exception\InvalidArgumentException');
+        $this->expectException(Storage\Exception\InvalidArgumentException::class);
         $protocol->readResponse();
     }
 

--- a/test/Transport/FactoryTest.php
+++ b/test/Transport/FactoryTest.php
@@ -7,14 +7,14 @@
 
 namespace ZendTest\Mail\Transport;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Transport\Factory;
 use Zend\Stdlib\ArrayObject;
 
 /**
  * @covers Zend\Mail\Transport\Factory<extended>
  */
-class FactoryTest extends PHPUnit_Framework_TestCase
+class FactoryTest extends TestCase
 {
     /**
      * @dataProvider invalidSpecTypeProvider

--- a/test/Transport/FileOptionsTest.php
+++ b/test/Transport/FileOptionsTest.php
@@ -9,13 +9,13 @@
 
 namespace ZendTest\Mail\Transport;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Transport\FileOptions;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Transport\FileOptions<extended>
  */
-class FileOptionsTest extends \PHPUnit_Framework_TestCase
+class FileOptionsTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Transport/FileTest.php
+++ b/test/Transport/FileTest.php
@@ -9,15 +9,15 @@
 
 namespace ZendTest\Mail\Transport;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Message;
 use Zend\Mail\Transport\File;
 use Zend\Mail\Transport\FileOptions;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Transport\File<extended>
  */
-class FileTest extends \PHPUnit_Framework_TestCase
+class FileTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Transport/InMemoryTest.php
+++ b/test/Transport/InMemoryTest.php
@@ -9,14 +9,14 @@
 
 namespace ZendTest\Mail\Transport;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Message;
 use Zend\Mail\Transport\InMemory;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Transport\InMemory<extended>
  */
-class InMemoryTest extends \PHPUnit_Framework_TestCase
+class InMemoryTest extends TestCase
 {
     public function getMessage()
     {

--- a/test/Transport/NullTest.php
+++ b/test/Transport/NullTest.php
@@ -9,12 +9,11 @@
 
 namespace ZendTest\Mail\Transport;
 
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Error\Deprecated;
 use Zend\Mail\Transport\Null as NullTransport;
 
-/**
- * @group      Zend_Mail
- */
-class NullTest extends \PHPUnit_Framework_TestCase
+class NullTest extends TestCase
 {
     public function setUp()
     {
@@ -25,7 +24,7 @@ class NullTest extends \PHPUnit_Framework_TestCase
 
     public function testRaisesNoticeOnInstantiation()
     {
-        $this->setExpectedException('PHPUnit_Framework_Error_Deprecated');
+        $this->expectException(Deprecated::class);
         new NullTransport();
     }
 }

--- a/test/Transport/SendmailTest.php
+++ b/test/Transport/SendmailTest.php
@@ -9,15 +9,15 @@
 
 namespace ZendTest\Mail\Transport;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Message;
 use Zend\Mail\Transport\Exception\RuntimeException;
 use Zend\Mail\Transport\Sendmail;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Transport\Sendmail<extended>
  */
-class SendmailTest extends \PHPUnit_Framework_TestCase
+class SendmailTest extends TestCase
 {
     public $transport;
     public $to;
@@ -143,7 +143,7 @@ class SendmailTest extends \PHPUnit_Framework_TestCase
         $message->addTo('hacker@localhost', 'Name of recipient');
         $message->setSubject('TestSubject');
 
-        $this->setExpectedException(RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->transport->send($message);
     }
 

--- a/test/Transport/SmtpTest.php
+++ b/test/Transport/SmtpTest.php
@@ -9,18 +9,19 @@
 
 namespace ZendTest\Mail\Transport;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mail\Headers;
 use Zend\Mail\Message;
+use Zend\Mail\Transport\Exception;
 use Zend\Mail\Transport\Smtp;
 use Zend\Mail\Transport\SmtpOptions;
 use Zend\Mail\Transport\Envelope;
 use ZendTest\Mail\TestAsset\SmtpProtocolSpy;
 
 /**
- * @group      Zend_Mail
  * @covers Zend\Mail\Transport\Smtp<extended>
  */
-class SmtpTest extends \PHPUnit_Framework_TestCase
+class SmtpTest extends TestCase
 {
     /** @var Smtp */
     public $transport;
@@ -60,10 +61,8 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
      */
     public function testSendMailWithoutMinimalHeaders()
     {
-        $this->setExpectedException(
-            'Zend\Mail\Transport\Exception\RuntimeException',
-            'transport expects either a Sender or at least one From address in the Message; none provided'
-        );
+        $this->expectException(Exception\RuntimeException::class);
+        $this->expectExceptionMessage('transport expects either a Sender or at least one From address in the Message; none provided');
         $message = new Message();
         $this->transport->send($message);
     }
@@ -74,10 +73,8 @@ class SmtpTest extends \PHPUnit_Framework_TestCase
      */
     public function testSendMailWithoutRecipient()
     {
-        $this->setExpectedException(
-            'Zend\Mail\Transport\Exception\RuntimeException',
-            'at least one recipient if the message has at least one header or body'
-        );
+        $this->expectException(Exception\RuntimeException::class);
+        $this->expectExceptionMessage('at least one recipient if the message has at least one header or body');
         $message = new Message();
         $message->setSender('ralph.schindler@zend.com', 'Ralph Schindler');
         $this->transport->send($message);

--- a/test/autoload.php
+++ b/test/autoload.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-mail for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-mail/blob/master/LICENSE.md New BSD License
+ */
+
+if (! class_exists(PHPUnit_Framework_Error_Deprecated::class)) {
+    class_alias(PHPUnit\Framework\Error\Deprecated::class, PHPUnit_Framework_Error_Deprecated::class);
+}


### PR DESCRIPTION
This patch updates the component to use either PHPUnit 5.7 or 6.0.

It also updates the Travis configuration to use the lowest/locked/latest strategy, and to add jobs for PHP 7.1.