### PR TITLE
fix regression: MessageId having double brackets

### DIFF
--- a/src/Header/MessageId.php
+++ b/src/Header/MessageId.php
@@ -68,6 +68,8 @@ class MessageId implements HeaderInterface
     {
         if ($id === null) {
             $id = $this->createMessageId();
+        } else {
+            $id = trim($id, '<>');
         }
 
         if (! HeaderValue::isValid($id)

--- a/test/Storage/MessageTest.php
+++ b/test/Storage/MessageTest.php
@@ -111,6 +111,19 @@ class MessageTest extends TestCase
         $this->assertEquals(substr($message->getContent(), 0, 6), "\t<?php");
     }
 
+    /**
+     * after pull/86 messageId gets double braces
+     *
+     * @see https://github.com/zendframework/zend-mail/pull/86
+     * @see https://github.com/zendframework/zend-mail/pull/156
+     */
+    public function testMessageIdHeader()
+    {
+        $message = new Message(['file' => $this->file]);
+        $messageId = $message->messageId;
+        $this->assertEquals('<CALTvGe4_oYgf9WsYgauv7qXh2-6=KbPLExmJNG7fCs9B=1nOYg@mail.example.com>', $messageId);
+    }
+
     public function testMultipleHeader()
     {
         $raw = file_get_contents($this->file);


### PR DESCRIPTION
this got broken from #86 when header lazyloading was omitted

```
Expected :'<CALTvGe4_oYgf9WsYgauv7qXh2-6=KbPLExmJNG7fCs9B=1nOYg@mail.example.com>'
Actual   :'<<CALTvGe4_oYgf9WsYgauv7qXh2-6=KbPLExmJNG7fCs9B=1nOYg@mail.example.com>>'
```