### PR TITLE
Protocol\Smtp cleanup

### DIFF
--- a/src/Protocol/Smtp.php
+++ b/src/Protocol/Smtp.php
@@ -248,8 +248,6 @@ class Smtp extends AbstractProtocol
         } catch (Exception\ExceptionInterface $e) {
             $this->_send('HELO ' . $host);
             $this->_expect(250, 300); // Timeout set for 5 minutes as per RFC 2821 4.5.3.2
-        } catch (\Exception $e) {
-            throw $e;
         }
     }
 


### PR DESCRIPTION
Since https://github.com/zendframework/zend-mail/commit/74e58f4c4507ea1d79baa54eddc2cc4d4e1cf8cb this likely isn't necessary anymore, is it?