### PR TITLE
Added missing dependency to zend-servicemanager (for --no-dev install)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "zendframework/zend-loader": "^2.5",
         "zendframework/zend-mime": "^2.5",
         "zendframework/zend-stdlib": "^2.7 || ^3.0",
-        "zendframework/zend-validator": "^2.6"
+        "zendframework/zend-validator": "^2.6",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3"
     },
     "require-dev": {
         "zendframework/zend-config": "^2.6",


### PR DESCRIPTION
If you want to use `zend-mail` as a standalone package and installed it with composer without dev requirements, usage results in a fatal error:  

`PHP Fatal error:  Class 'Zend\ServiceManager\AbstractPluginManager' not found in $project/vendor/zendframework/zend-mail/src/Protocol/SmtpPluginManager.php`
