### PR TITLE
Add PHPDoc comments

### DIFF
--- a/src/Address.php
+++ b/src/Address.php
@@ -23,7 +23,6 @@ class Address implements Address\AddressInterface
      * @param  string $email
      * @param  null|string $name
      * @throws Exception\InvalidArgumentException
-     * @return Address
      */
     public function __construct($email, $name = null)
     {

--- a/src/Header/GenericHeader.php
+++ b/src/Header/GenericHeader.php
@@ -30,6 +30,10 @@ class GenericHeader implements HeaderInterface, UnstructuredInterface
      */
     protected $encoding;
 
+    /**
+     * @param string $headerLine
+     * @return GenericHeader
+     */
     public static function fromString($headerLine)
     {
         list($name, $value) = self::splitHeaderLine($headerLine);

--- a/src/Headers.php
+++ b/src/Headers.php
@@ -14,6 +14,8 @@ use Countable;
 use Iterator;
 use Traversable;
 use Zend\Loader\PluginClassLocator;
+use Zend\Mail\Header\GenericHeader;
+use Zend\Mail\Header\HeaderInterface;
 
 /**
  * Basic mail headers collection functionality
@@ -478,6 +480,8 @@ class Headers implements Countable, Iterator
     public function loadHeader($headerLine)
     {
         list($name, ) = Header\GenericHeader::splitHeaderLine($headerLine);
+
+        /** @var HeaderInterface $class */
         $class = $this->getPluginClassLoader()->load($name) ?: Header\GenericHeader::class;
         return $class::fromString($headerLine);
     }
@@ -491,6 +495,8 @@ class Headers implements Countable, Iterator
         $current = $this->headers[$index];
 
         $key   = $this->headersKeys[$index];
+
+        /** @var GenericHeader $class */
         $class = ($this->getPluginClassLoader()->load($key)) ?: 'Zend\Mail\Header\GenericHeader';
 
         $encoding = $current->getEncoding();

--- a/src/Message.php
+++ b/src/Message.php
@@ -10,6 +10,8 @@
 namespace Zend\Mail;
 
 use Traversable;
+use Zend\Mail\Header\ContentType;
+use Zend\Mail\Header\Sender;
 use Zend\Mime;
 
 class Message
@@ -17,7 +19,7 @@ class Message
     /**
      * Content of the message
      *
-     * @var string|object
+     * @var string|object|Mime\Message
      */
     protected $body;
 
@@ -302,6 +304,7 @@ class Message
      */
     public function setSender($emailOrAddress, $name = null)
     {
+        /** @var Sender $header */
         $header = $this->getHeaderByName('sender', __NAMESPACE__ . '\Header\Sender');
         $header->setAddress($emailOrAddress, $name);
         return $this;
@@ -318,6 +321,8 @@ class Message
         if (! $headers->has('sender')) {
             return null;
         }
+
+        /** @var Sender $header */
         $header = $this->getHeaderByName('sender', __NAMESPACE__ . '\Header\Sender');
         return $header->getAddress();
     }
@@ -397,6 +402,8 @@ class Message
         // Multipart content headers
         if ($this->body->isMultiPart()) {
             $mime   = $this->body->getMime();
+
+            /** @var ContentType $header */
             $header = $this->getHeaderByName('content-type', __NAMESPACE__ . '\Header\ContentType');
             $header->setType('multipart/mixed');
             $header->addParameter('boundary', $mime->boundary());
@@ -415,7 +422,7 @@ class Message
     /**
      * Return the currently set message body
      *
-     * @return object
+     * @return object|string|Mime\Message
      */
     public function getBody()
     {
@@ -553,6 +560,8 @@ class Message
     public static function fromString($rawMessage)
     {
         $message = new static();
+
+        /** @var Headers $headers */
         $headers = null;
         $content = null;
         Mime\Decode::splitMessage($rawMessage, $headers, $content, Headers::EOL);

--- a/src/Protocol/Smtp.php
+++ b/src/Protocol/Smtp.php
@@ -160,6 +160,7 @@ class Smtp extends AbstractProtocol
      * Set whether or not send QUIT command
      *
      * @param int $useCompleteQuit use complete quit
+     * @return bool
      */
     public function setUseCompleteQuit($useCompleteQuit)
     {

--- a/src/Transport/Sendmail.php
+++ b/src/Transport/Sendmail.php
@@ -152,6 +152,7 @@ class Sendmail implements TransportInterface
             throw new Exception\RuntimeException('Invalid email; contains no "To" header');
         }
 
+        /** @var Mail\Header\To $to */
         $to   = $headers->get('to');
         $list = $to->getAddressList();
         if (0 == count($list)) {
@@ -225,7 +226,7 @@ class Sendmail implements TransportInterface
         $headers->removeHeader('To');
         $headers->removeHeader('Subject');
 
-        // Sanitize the From header
+        /** @var Mail\Header\From $from Sanitize the From header*/
         $from = $headers->get('From');
         if ($from) {
             foreach ($from->getAddressList() as $address) {


### PR DESCRIPTION
In some cases, the IDE can not recognize the types of variables. To solve this problem, I've added comments in some places.
And I added comments for the following methods
 - Add missing comment for method GenericHeader::fromString
 - Add PHPDoc @return comment for Smtp::setUseCompleteQuit() method
 - PHPDoc @return comment does not apply to the constructor because remove this comment for Address::__construct
 - Add Mime\Message type for Mail\Message::$body property.