### PR TITLE
Header Parsing Error

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,7 @@
 
     <php>
         <ini name="date.timezone" value="UTC"/>
+        <ini name="error_reporting" value="-1"/>
 
         <!-- OB_ENABLED should be enabled for some tests to check if all
              functionality works as expected. Such tests include those for

--- a/src/Header/ContentType.php
+++ b/src/Header/ContentType.php
@@ -40,19 +40,25 @@ class ContentType implements UnstructuredInterface
         }
 
         $value  = str_replace(Headers::FOLDING, ' ', $value);
-        $values = preg_split('#\s*;\s*#', $value);
+        $parts = explode(';', $value, 2);
 
-        $type   = array_shift($values);
+        $type = $parts[0];
+        $pairs = null;
+
+        if (isset($parts[1])) {
+            $pairs = $parts[1];
+        }
+
         $header = new static();
         $header->setType($type);
 
-        // Remove empty values
-        $values = array_filter($values);
+        if (null !== $pairs) {
+            parse_str(str_replace('";', '"&', $pairs), $values);
 
-        foreach ($values as $keyValuePair) {
-            list($key, $value) = explode('=', $keyValuePair, 2);
-            $value = trim($value, "'\" \t\n\r\0\x0B");
-            $header->addParameter($key, $value);
+            foreach ($values as $key => $value) {
+                $value = trim($value, "'\" \t\n\r\0\x0B");
+                $header->addParameter($key, $value);
+            }
         }
 
         return $header;

--- a/test/Header/ContentTypeTest.php
+++ b/test/Header/ContentTypeTest.php
@@ -45,6 +45,12 @@ class ContentTypeTest extends TestCase
         $this->assertEquals($header->getParameters(), ['name' => 'foo.pdf']);
     }
 
+    public function testHandlesSemiColonInLiterals()
+    {
+        $header = ContentType::fromString('Content-Type: text/plain; name="foo; bar.txt"');
+        $this->assertEquals($header->getParameters(), ['name' => 'foo; bar.txt']);
+    }
+
     /**
      * @dataProvider setTypeProvider
      */


### PR DESCRIPTION
I've added a failing test case for an error I'm running into in strict mode with real email data, not sure on the options for fixing if it's an invalid header? Or suppressing the error would be ok? Or more robust parsing of the header is needed?

The problem is the semi-colon being used as a delimiter for splitting, when it seems it can be valid to occur in pair values when quoted as a literal...