### PR TITLE
Fix deprecated variant in idn_to_ascii

### DIFF
--- a/src/Header/AbstractAddressList.php
+++ b/src/Header/AbstractAddressList.php
@@ -102,7 +102,7 @@ abstract class AbstractAddressList implements HeaderInterface
     protected function idnToAscii($domainName)
     {
         if (extension_loaded('intl')) {
-            return (idn_to_ascii($domainName) ?: $domainName);
+            return (idn_to_ascii($domainName, 0, INTL_IDNA_VARIANT_UTS46) ?: $domainName);
         }
         return $domainName;
     }

--- a/src/Header/AbstractAddressList.php
+++ b/src/Header/AbstractAddressList.php
@@ -102,7 +102,11 @@ abstract class AbstractAddressList implements HeaderInterface
     protected function idnToAscii($domainName)
     {
         if (extension_loaded('intl')) {
-            return (idn_to_ascii($domainName, 0, INTL_IDNA_VARIANT_UTS46) ?: $domainName);
+            if (defined('INTL_IDNA_VARIANT_UTS46')) {
+                return (idn_to_ascii($domainName, 0, INTL_IDNA_VARIANT_UTS46) ?: $domainName);
+            } else {
+                return (idn_to_ascii($domainName) ?: $domainName);                
+            }
         }
         return $domainName;
     }


### PR DESCRIPTION
In PHP 7.2, INTL_IDNA_VARIANT_2003 is deprecated in 
PHP Deprecated:  idn_to_ascii(): INTL_IDNA_VARIANT_2003 is deprecated in zendframework\zend-mail\src\Header\AbstractAddressList.php on line 105

Reference issue: https://github.com/zendframework/zend-mail/issues/177