### PR TITLE
PHPDoc: `Message#getBody()` can also return a `string`

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -415,7 +415,7 @@ class Message
     /**
      * Return the currently set message body
      *
-     * @return object
+     * @return string|object
      */
     public function getBody()
     {


### PR DESCRIPTION
Body can also be a string:
https://github.com/zendframework/zend-mail/blob/d787bf7e2ad88bdd79fbf5431b35acbac79408a0/src/Message.php#L17-L22