### PR TITLE
Use the INTL_IDNA_VARIANT_UTS46 idn_to_ascii variant

### DIFF
--- a/src/Header/AbstractAddressList.php
+++ b/src/Header/AbstractAddressList.php
@@ -102,6 +102,9 @@ abstract class AbstractAddressList implements HeaderInterface
     protected function idnToAscii($domainName)
     {
         if (extension_loaded('intl')) {
+            if (defined('INTL_IDNA_VARIANT_UTS46')) {
+                return (idn_to_ascii($domainName, 0, INTL_IDNA_VARIANT_UTS46) ?: $domainName);
+            }
             return (idn_to_ascii($domainName) ?: $domainName);
         }
         return $domainName;


### PR DESCRIPTION
The default variant INTL_IDNA_VARIANT_2003 is deprecated in php 7.2.
The default will be changed to INTL_IDNA_VARIANT_UTS46 in php 7.4 so we should use that if it is defined.
This is similar to how it was changed in `Zend\Validator\EmailAddress`.