### PR TITLE
Content Type Header Parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
+- [#211](https://github.com/zendframework/zend-mail/pull/211) fixes how the `ContentType` header class parses the value it receives. Previously,
+  it was incorrectly splitting the value on semi-colons that were inside quotes; in now correctly
+  ignores them.
+
 - [#204](https://github.com/zendframework/zend-mail/pull/204) fixes `HeaderWrap::mimeDecodeValue()` behavior when handling a multiline UTF-8
   header split across a character. The fix will only work when ext-imap is present, however.
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,7 @@
 
     <php>
         <ini name="date.timezone" value="UTC"/>
+        <ini name="error_reporting" value="-1"/>
 
         <!-- OB_ENABLED should be enabled for some tests to check if all
              functionality works as expected. Such tests include those for

--- a/src/Header/AbstractAddressList.php
+++ b/src/Header/AbstractAddressList.php
@@ -58,7 +58,7 @@ abstract class AbstractAddressList implements HeaderInterface
         // split value on ","
         $fieldValue = str_replace(Headers::FOLDING, ' ', $fieldValue);
         $fieldValue = preg_replace('/[^:]+:([^;]*);/', '$1,', $fieldValue);
-        $values = AddressListParser::parse($fieldValue);
+        $values = ListParser::parse($fieldValue);
 
         $wasEncoded = false;
         $addresses = array_map(

--- a/src/Header/AddressListParser.php
+++ b/src/Header/AddressListParser.php
@@ -17,9 +17,10 @@ class AddressListParser
 
     /**
      * @param string $value
+     * @param array $delims
      * @return array
      */
-    public static function parse($value)
+    public static function parse($value, $delims = self::CHAR_DELIMS)
     {
         $values            = [];
         $length            = strlen($value);
@@ -40,7 +41,7 @@ class AddressListParser
 
             // If we are not in a quoted string, and have a delimiter, append
             // the current value to the list, and reset the current value.
-            if (in_array($char, self::CHAR_DELIMS, true) && ! $inQuote) {
+            if (in_array($char, $delims, true) && ! $inQuote) {
                 $values [] = $currentValue;
                 $currentValue = '';
                 continue;

--- a/src/Header/AddressListParser.php
+++ b/src/Header/AddressListParser.php
@@ -20,7 +20,7 @@ class AddressListParser
      * @param array $delims
      * @return array
      */
-    public static function parse($value, $delims = self::CHAR_DELIMS)
+    public static function parse($value, array $delims = self::CHAR_DELIMS)
     {
         $values            = [];
         $length            = strlen($value);

--- a/src/Header/ContentType.php
+++ b/src/Header/ContentType.php
@@ -40,19 +40,20 @@ class ContentType implements UnstructuredInterface
         }
 
         $value  = str_replace(Headers::FOLDING, ' ', $value);
-        $values = preg_split('#\s*;\s*#', $value);
+        $parts = explode(';', $value, 2);
 
-        $type   = array_shift($values);
         $header = new static();
-        $header->setType($type);
+        $header->setType($parts[0]);
 
-        // Remove empty values
-        $values = array_filter($values);
+        if (isset($parts[1])) {
+            $values = AddressListParser::parse(trim($parts[1]), [';', '=']);
+            $length = count($values);
 
-        foreach ($values as $keyValuePair) {
-            list($key, $value) = explode('=', $keyValuePair, 2);
-            $value = trim($value, "'\" \t\n\r\0\x0B");
-            $header->addParameter($key, $value);
+            for ($i = 0; $i < $length; $i += 2) {
+                $value = $values[$i + 1];
+                $value = trim($value, "'\" \t\n\r\0\x0B");
+                $header->addParameter($values[$i], $value);
+            }
         }
 
         return $header;

--- a/src/Header/ContentType.php
+++ b/src/Header/ContentType.php
@@ -46,7 +46,7 @@ class ContentType implements UnstructuredInterface
         $header->setType($parts[0]);
 
         if (isset($parts[1])) {
-            $values = AddressListParser::parse(trim($parts[1]), [';', '=']);
+            $values = ListParser::parse(trim($parts[1]), [';', '=']);
             $length = count($values);
 
             for ($i = 0; $i < $length; $i += 2) {

--- a/src/Header/ListParser.php
+++ b/src/Header/ListParser.php
@@ -9,7 +9,7 @@ namespace Zend\Mail\Header;
 
 use function in_array;
 
-class AddressListParser
+class ListParser
 {
     const CHAR_QUOTES = ['\'', '"'];
     const CHAR_DELIMS = [',', ';'];
@@ -17,7 +17,9 @@ class AddressListParser
 
     /**
      * @param string $value
-     * @param array $delims
+     * @param array $delims Delimiters allowed between values; parser will
+     *     split on these, as long as they are not within quotes. Defaults
+     *     to ListParser::CHAR_DELIMS.
      * @return array
      */
     public static function parse($value, array $delims = self::CHAR_DELIMS)

--- a/test/Header/ContentTypeTest.php
+++ b/test/Header/ContentTypeTest.php
@@ -45,6 +45,29 @@ class ContentTypeTest extends TestCase
         $this->assertEquals($header->getParameters(), ['name' => 'foo.pdf']);
     }
 
+    public static function getLiteralData()
+    {
+        return [
+            [
+                ['name' => 'foo; bar.txt'],
+                'text/plain; name="foo; bar.txt"'
+            ],
+            [
+                ['name' => 'foo&bar.txt'],
+                'text/plain; name="foo&bar.txt"'
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getLiteralData
+     */
+    public function testHandlesLiterals(array $expected, $header)
+    {
+        $header = ContentType::fromString('Content-Type: '.$header);
+        $this->assertEquals($expected, $header->getParameters());
+    }
+
     /**
      * @dataProvider setTypeProvider
      */


### PR DESCRIPTION
When parsing the `Content-Type` header there is an assumption that the type and key/value pairs can be split by semi-colon, but this is incorrect when a value contains a semi-colon (eg. `name="foo; bar"`). This format is covered by the RFC (https://tools.ietf.org/html/rfc2045#page-12, `Must be in quoted-string to use within parameter values`), and is seen in data in the wild.  This patch adds support for this.

Currently an exception is thrown in strict mode because of an undefined offset (`Undefined offset: 1`). I've updated the code to use `parse_str` to better handle this data, which I think is an improvement over the regexp splitting, but still not ideal without a proper lexer/tokenizer obv.

I've also enabled strict mode for PHPUnit by default to expose these kinds of bugs in the test suite.