### PR TITLE
Allow PHP 5.6 and 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,26 @@ env:
 
 matrix:
   include:
+    - php: 5.6
+      env:
+        - DEPS=lowest
+    - php: 5.6
+      env:
+        - DEPS=locked
+        - LEGACY_DEPS="phpunit/phpunit"
+    - php: 5.6
+      env:
+        - DEPS=latest
+    - php: 7.0
+      env:
+        - DEPS=lowest
+    - php: 7.0
+      env:
+        - DEPS=locked
+        - LEGACY_DEPS="phpunit/phpunit"
+    - php: 7.0
+      env:
+        - DEPS=latest
     - php: 7.1
       env:
         - DEPS=lowest
@@ -38,7 +58,8 @@ before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
 
 install:
-  - travis_retry composer install $COMPOSER_ARGS
+  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
+  - if [[ $LEGACY_DEPS != '' ]]; then travis_retry composer update --with-dependencies $COMPOSER_ARGS $LEGACY_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,6 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 3.0.0 - TBD
-
-### Added
-
-- Nothing.
-
-### Deprecated
-
-- Nothing.
-
-### Removed
-
-- Nothing.
-
-### Fixed
-
-- Nothing.
-
 ## 2.9.1 - TBD
 
 ### Added
@@ -74,7 +56,7 @@ All notable changes to this project will be documented in this file, in reverse 
 - [#143](https://github.com/zendframework/zend-mail/pull/143) fixed parsing
   of `<` and `>` being part of the email address comment.
 
-## 2.8.0 - TBD
+## 2.8.0 - 2017-06-08
 
 ### Added
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "forum": "https://discourse.zendframework.com/c/questions/components"
     },
     "require": {
-        "php": "^7.1",
+        "php": "^5.6 || ^7.0",
         "ext-iconv": "*",
         "zendframework/zend-loader": "^2.5",
         "zendframework/zend-mime": "^2.5",
@@ -24,11 +24,11 @@
         "zendframework/zend-validator": "^2.10.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.1.4",
+        "phpunit/phpunit": "^5.7.25 || ^6.4.4 || ^7.1.4",
         "zendframework/zend-coding-standard": "~1.0.0",
         "zendframework/zend-config": "^2.6",
         "zendframework/zend-crypt": "^2.6 || ^3.0",
-        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3"
+        "zendframework/zend-servicemanager": "^2.7.10 || ^3.3.1"
     },
     "suggest": {
         "ext-intl": "Handle IDN in AddressList hostnames",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c591e9e4d63399436050ede1273e432",
+    "content-hash": "aa92ab285ab2e2b89e7c3114332ff458",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -2144,7 +2144,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1",
+        "php": "^5.6 || ^7.0",
         "ext-iconv": "*"
     },
     "platform-dev": []


### PR DESCRIPTION
We're not supposed to bump to a new major version of PHP in a minor release, which is what happened in 2.9.0. This patch reverts that, while keeping compatibility with PHP 7.2.