### PR TITLE
Return-Path Email is not used

### DIFF
--- a/src/Transport/Sendmail.php
+++ b/src/Transport/Sendmail.php
@@ -258,12 +258,16 @@ class Sendmail implements TransportInterface
             return;
         }
 
-        $parameters = (string) $this->parameters;
+        $parameters = '';
+        $priorityParameters = '';
+
+        if ($this->parameters)
+            $priorityParameters = (string) $this->parameters;
 
         $sender = $message->getSender();
         if ($sender instanceof AddressInterface) {
             $parameters .= ' -f' . \escapeshellarg($sender->getEmail());
-            return $parameters;
+            return $parameters . $priorityParameters;
         }
 
         $from = $message->getFrom();
@@ -271,10 +275,10 @@ class Sendmail implements TransportInterface
             $from->rewind();
             $sender      = $from->current();
             $parameters .= ' -f' . \escapeshellarg($sender->getEmail());
-            return $parameters;
+            return $parameters . $priorityParameters;
         }
 
-        return $parameters;
+        return $parameters . $priorityParameters;
     }
 
     /**


### PR DESCRIPTION
## Description 

E-mail Return-Path is not set correctly because it only uses the last forced e-mail address, so as workaround I implemented this code change to give priority to the e-mail address that is already stored in the parameters and therefore the return path mail will be set correctly.

E.g. $parameters = " '-f test1@mail.com' '-f test2@mail.com'";
It will use 'test2@mail.com' as return path email.

## Magento 2.3.0 Alpha: steps to reproduce
     1 - Admin store: Stores > Settings > Configuration > Advanced > System > Mail Sending Settings > Return-Path Email - set a different return path email
     2 - Place an order
     3 - Look for ´Return-Path: <new return path email>' in the email