### PR TITLE
fix problem sending mail through SMTP transport when "composer instal…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,14 @@
         "zendframework/zend-mime": "^2.5",
         "zendframework/zend-stdlib": "^2.7 || ^3.0",
         "zendframework/zend-validator": "^2.10.2",
+        "zendframework/zend-servicemanager": "^2.7.10 || ^3.3.1",
         "true/punycode": "^2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.25 || ^6.4.4 || ^7.1.4",
         "zendframework/zend-coding-standard": "~1.0.0",
         "zendframework/zend-config": "^2.6",
-        "zendframework/zend-crypt": "^2.6 || ^3.0",
-        "zendframework/zend-servicemanager": "^2.7.10 || ^3.3.1"
+        "zendframework/zend-crypt": "^2.6 || ^3.0"
     },
     "suggest": {
         "zendframework/zend-crypt": "Crammd5 support in SMTP Auth",


### PR DESCRIPTION
…l -no-dev"

Steps to problem:
1. compser install --no-dev
2. sending mail through SMTP transport
3. return result:
Fatal error: Class 'Zend \ ServiceManager \ AbstractPluginManager' not found in C: \ htdocs \ gpsman \ vendor \ zendframework \ zend-mail \ src \ Protocol \ SmtpPluginManager.php on line 20

Incorrect behavior:
in file compser,json in section "require" missing directive "zendframework/zend-servicemanager": "^2.7.10 || ^3.3.1", without which, in the "--no-dev" mode, when sending a message, an error occurs.

Provide a narrative description of what you are trying to accomplish:

- [ ] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
