### PR TITLE
Add test for #147 regression

### DIFF
--- a/test/AddressListTest.php
+++ b/test/AddressListTest.php
@@ -144,4 +144,25 @@ class AddressListTest extends TestCase
         $this->assertTrue($addressList->has('asda.fasd@example.net'));
         $this->assertTrue($addressList->has('root@example.org'));
     }
+
+    /**
+     * If name-field is quoted with "", then ' inside it should not treated as terminator, but as value.
+     */
+    public function testMixedQuotesInName() {
+        $header = '"Bob O\'Reilly" <bob@example.com>,blah@example.com';
+
+        // In previous versions, this throws:
+        // 'Bob O'Reilly <bob@example.com>,blah' can not be matched against dot-atom format
+        // hence the try/catch block, to allow finding the root cause.
+        try {
+            $to = Header\To::fromString('To:' . $header);
+        } catch (InvalidArgumentException $e) {
+            $this->fail('Header\To::fromString should not throw. Exception message: ' . $e->getMessage());
+        }
+
+        $addressList = $to->getAddressList();
+        $this->assertTrue($addressList->has('bob@example.com'));
+        $this->assertTrue($addressList->has('blah@example.com'));
+        $this->assertEquals("Bob O'Reilly", $addressList->get('bob@example.com')->getName());
+    }
 }


### PR DESCRIPTION
Add test for #147 regression:

Looks like the new parser class treats `"` and `'` equally, thus `'"Bob O\'Reilly" <bob@example.com>,blah@example.com'` does not parse properly.

cc @weierophinney 

<!--
Provide a narrative description of what you are trying to accomplish:

- [ ] Are you fixing a bug?
  - [ ] Detail how the bug is invoked currently.
  - [ ] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

-->