### PR TITLE
Treat quote as value if already in quote using another delimiter

### DIFF
--- a/src/Header/ListParser.php
+++ b/src/Header/ListParser.php
@@ -76,6 +76,12 @@ class ListParser
                 continue;
             }
 
+            // If already in quote and the character does not match the previously
+            // matched quote delimiter, we're done here.
+            if ($inQuote) {
+                continue;
+            }
+
             // Otherwise, we're starting a quoted string.
             $inQuote = true;
             $currentQuoteDelim = $char;

--- a/test/Header/ListParser.php
+++ b/test/Header/ListParser.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-mail for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-mail/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Mail\Header;
+
+use PHPUnit\Framework\TestCase;
+use Zend\Mail\Header\ListParser;
+
+/**
+ * @covers Zend\Mail\Header\ListParser<extended>
+ */
+class ListParserTest extends TestCase
+{
+    public function testParseIgnoreQuoteDelimiterIfAlreadyInQuote()
+    {
+        $parsed = ListParser::parse('"john\'doe" <john@doe.com>,jane <jane@doe.com>');
+        $this->assertEquals($parsed, [
+            '"john\'doe" <john@doe.com>',
+            'jane <jane@doe.com>'
+        ]);
+    }
+}


### PR DESCRIPTION
Fixes the issue as described in #222.