### PR TITLE
Add in the required type for the content part

### DIFF
--- a/docs/book/message/attachments.md
+++ b/docs/book/message/attachments.md
@@ -116,7 +116,8 @@ $content = new MimeMessage();
 // This order is important for email clients to properly display the correct version of the content
 $content->setParts([$text, $html]);
 
-$contentPart = new MimePart($content->generateMessage());
+$contentPart       = new MimePart($content->generateMessage());
+$contentPart->type = 'multipart/alternative; boundary="' . $contentPart->getMime()->boundary() . '"';
 
 $image              = new MimePart(fopen($pathToImage, 'r'));
 $image->type        = 'image/jpeg';


### PR DESCRIPTION
The current documentation is missing this crucial requirement for the multipart/alternative + attachments section.

This had me stumped for a long time and I finally found the solution here:
https://akrabat.com/sending-attachments-in-multipart-emails-with-zendmail/

Note that the \n character is not necessary (and I think in some clients causes errors).