### PR TITLE
Replace error handler with error_get_last() function 

### DIFF
--- a/src/Transport/Sendmail.php
+++ b/src/Transport/Sendmail.php
@@ -289,16 +289,14 @@ class Sendmail implements TransportInterface
      */
     public function mailHandler($to, $subject, $message, $headers, $parameters)
     {
-        set_error_handler([$this, 'handleMailErrors']);
         if ($parameters === null) {
             $result = mail($to, $subject, $message, $headers);
         } else {
             $result = mail($to, $subject, $message, $headers, $parameters);
         }
-        restore_error_handler();
 
-        if ($this->errstr !== null || ! $result) {
-            $errstr = $this->errstr;
+        if (!$result) {
+            $errstr = error_get_last()['message'];
             if (empty($errstr)) {
                 $errstr = 'Unknown error';
             }


### PR DESCRIPTION
Hi, guys.

I just found that `mail()` function does not generate the proper error that can be handled by `handleMailErrors()` method ("_Temporary error handler for PHP native mail()_" as pointed in the phpdoc). I have an [msmtp](https://marlam.de/msmtp/) as email agent with following settings in `php.ini`:
```
sendmail_path = "/usr/bin/msmtp -C /etc/.msmtp.fpm --logfile /var/log/msmtp.log --read-envelope-from -a gmail -t"
```
I have an error in `\Zend\Mail\Transport\Sendmail::mailHandler` if
```
$parameters = " -f'sender@email.com'";
```

in
```
$result = mail($to, $subject, $message, $headers, $parameters);
```

As I see, there is a conflict between `--read-envelope-from` option of `msmtp` and ` -f'sender@email.com'` parameter of `mail` function. So, `mail` function returns `false` in this case.


But this code does not handle the error as expected. The breakpoint in `handleMailErrors` method does not activated when error occurs (I have PHP 7.2.19 & PHPStorm 2019.1.3).

I [found](https://stackoverflow.com/questions/3186725/how-can-i-get-the-error-message-for-the-mail-function) that `error_get_last()` function may help in this case.

In addition I think we should not throw an exception if `$result` is `true`.

So, I suppose, the final code for `mailHandler` should be the following:
```
public function mailHandler($to, $subject, $message, $headers, $parameters)
{
    if ($parameters === null) {
        $result = mail($to, $subject, $message, $headers);
    } else {
        $result = mail($to, $subject, $message, $headers, $parameters);
    }

    if (!$result) {
        $errstr = error_get_last()['message'];
        if (empty($errstr)) {
            $errstr = 'Unknown error';
        }
        throw new Exception\RuntimeException('Unable to send mail: ' . $errstr);
    }
}
```

Sorry, my qualification is not enough to complete all items you want to see here (regression test, CHANGELOG.md, etc.).  But I hope my point of view may be useful. 

Have a good day!