### PR TITLE
fix read of 8192 bytes failed with errno=21 Is a directory

### DIFF
--- a/src/Storage/Mbox.php
+++ b/src/Storage/Mbox.php
@@ -216,8 +216,8 @@ class Mbox extends AbstractStorage
      */
     protected function isMboxFile($file, $fileIsString = true)
     {
+        ErrorHandler::start(E_NOTICE);
         if ($fileIsString) {
-            ErrorHandler::start(E_WARNING);
             $file = fopen($file, 'r');
             ErrorHandler::stop();
             if (! $file) {
@@ -230,15 +230,15 @@ class Mbox extends AbstractStorage
         $result = false;
 
         $line = fgets($file) ?: '';
+
         if (strpos($line, 'From ') === 0) {
             $result = true;
         }
 
         if ($fileIsString) {
-            ErrorHandler::start(E_WARNING);
             fclose($file);
-            ErrorHandler::stop();
         }
+        ErrorHandler::stop();
 
         return $result;
     }


### PR DESCRIPTION
With 7.4.0RC3

```
There was 1 error:
1) ZendTest\Mail\Storage\MboxFolderTest::testChangeFolderUnselectable
fgets(): read of 8192 bytes failed with errno=21 Is a directory
/builddir/build/BUILDROOT/php-zendframework-zend-mail-2.10.0-5.fc32.noarch/usr/share/php/Zend/Mail/Storage/Mbox.php:232
/builddir/build/BUILDROOT/php-zendframework-zend-mail-2.10.0-5.fc32.noarch/usr/share/php/Zend/Mail/Storage/Mbox.php:268
/builddir/build/BUILDROOT/php-zendframework-zend-mail-2.10.0-5.fc32.noarch/usr/share/php/Zend/Mail/Storage/Folder/Mbox.php:164
/builddir/build/BUILD/zend-mail-d7beb63d5f7144a21ac100072c453e63860cdab8/test/Storage/MboxFolderTest.php:143
```

This is a trivial fix which "also" mute E_NOTICE raised by fgets