### PR TITLE
Add option novalidatecert to connect()

### DIFF
--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -19,6 +19,12 @@ class Imap
     const TIMEOUT_CONNECTION = 30;
 
     /**
+     * Do not validate the SSL certificate if set to true
+     * @var null|bool
+     */
+    public $novalidatecert;
+    
+    /**
      * socket to imap server
      * @var resource|null
      */
@@ -62,7 +68,7 @@ class Imap
      * @throws Exception\RuntimeException
      * @return string welcome message
      */
-    public function connect($host, $port = null, $ssl = false, $novalidatecert = false)
+    public function connect($host, $port = null, $ssl = false)
     {
         $isTls = false;
 
@@ -88,7 +94,7 @@ class Imap
         
         $socket_options = [];
         
-        if ($novalidatecert) {
+        if ($this->novalidatecert) {
         	$socket_options = [
         		'ssl' => [
         			'verify_peer_name' => false,

--- a/src/Protocol/Pop3.php
+++ b/src/Protocol/Pop3.php
@@ -25,6 +25,12 @@ class Pop3
     public $hasTop = null;
 
     /**
+     * Do not validate the SSL certificate if set to true
+     * @var null|bool
+     */
+    public $novalidatecert;
+    
+    /**
      * socket to pop3
      * @var null|resource
      */
@@ -67,7 +73,7 @@ class Pop3
      * @throws Exception\RuntimeException
      * @return string welcome message
      */
-    public function connect($host, $port = null, $ssl = false, $novalidatecert = false)
+    public function connect($host, $port = null, $ssl = false)
     {
         $isTls = false;
 
@@ -93,7 +99,7 @@ class Pop3
         
         $socket_options = [];
         
-        if ($novalidatecert) {
+        if ($this->novalidatecert) {
 	        $socket_options = [
 	        	'ssl' => [
 	        		'verify_peer_name' => false,

--- a/src/Storage/Imap.php
+++ b/src/Storage/Imap.php
@@ -210,9 +210,10 @@ class Imap extends AbstractStorage implements Folder\FolderInterface, Writable\W
         $password = isset($params->password) ? $params->password : '';
         $port     = isset($params->port) ? $params->port : null;
         $ssl      = isset($params->ssl) ? $params->ssl : false;
+        $novalidatecert = isset($params->novalidatecert) ? $params->novalidatecert : false;
 
         $this->protocol = new Protocol\Imap();
-        $this->protocol->connect($host, $port, $ssl);
+        $this->protocol->connect($host, $port, $ssl, $novalidatecert);
         if (! $this->protocol->login($params->user, $password)) {
             throw new Exception\RuntimeException('cannot login, user or password wrong');
         }

--- a/src/Storage/Imap.php
+++ b/src/Storage/Imap.php
@@ -210,10 +210,14 @@ class Imap extends AbstractStorage implements Folder\FolderInterface, Writable\W
         $password = isset($params->password) ? $params->password : '';
         $port     = isset($params->port) ? $params->port : null;
         $ssl      = isset($params->ssl) ? $params->ssl : false;
-        $novalidatecert = isset($params->novalidatecert) ? $params->novalidatecert : false;
 
         $this->protocol = new Protocol\Imap();
-        $this->protocol->connect($host, $port, $ssl, $novalidatecert);
+        
+        if (isset($params->novalidatecert)) {
+        	$this->protocol->novalidatecert = $params->novalidatecert;
+        }
+        
+        $this->protocol->connect($host, $port, $ssl);
         if (! $this->protocol->login($params->user, $password)) {
             throw new Exception\RuntimeException('cannot login, user or password wrong');
         }

--- a/src/Storage/Pop3.php
+++ b/src/Storage/Pop3.php
@@ -143,10 +143,14 @@ class Pop3 extends AbstractStorage
         $password = isset($params->password) ? $params->password : '';
         $port     = isset($params->port) ? $params->port : null;
         $ssl      = isset($params->ssl) ? $params->ssl : false;
-        $novalidatecert = isset($params->novalidatecert) ? $params->novalidatecert : false;
-
+        
         $this->protocol = new Protocol\Pop3();
-        $this->protocol->connect($host, $port, $ssl, $novalidatecert);
+        
+        if (isset($params->novalidatecert)) {
+        	$this->protocol->novalidatecert = $params->novalidatecert;
+        }
+        
+        $this->protocol->connect($host, $port, $ssl);
         $this->protocol->login($params->user, $password);
     }
 

--- a/src/Storage/Pop3.php
+++ b/src/Storage/Pop3.php
@@ -143,9 +143,10 @@ class Pop3 extends AbstractStorage
         $password = isset($params->password) ? $params->password : '';
         $port     = isset($params->port) ? $params->port : null;
         $ssl      = isset($params->ssl) ? $params->ssl : false;
+        $novalidatecert = isset($params->novalidatecert) ? $params->novalidatecert : false;
 
         $this->protocol = new Protocol\Pop3();
-        $this->protocol->connect($host, $port, $ssl);
+        $this->protocol->connect($host, $port, $ssl, $novalidatecert);
         $this->protocol->login($params->user, $password);
     }
 


### PR DESCRIPTION
This commit is a proposed fix for the following issue:
https://github.com/zendframework/zend-mail/issues/84
It introduces an optional parameter `novalidatecert` both for POP3 and IMAP, which makes it possible to  connect to mail servers with self-signed certificates, e.g. for development purposes. 