### PR TITLE
Always encode content-disposition as ASCII

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- Force encoding for `content-disposition` header to ASCII.
 
 ## 2.10.0 - 2018-06-07
 

--- a/src/Header/ContentDisposition.php
+++ b/src/Header/ContentDisposition.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-mail for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-mail/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Mail\Header;
+
+class ContentDisposition extends GenericHeader
+{
+    /**
+     * @var string
+     */
+    protected $fieldName = 'Content-Disposition';
+
+    /**
+     * @var string
+     */
+    protected $fieldValue = 'inline';
+
+    /**
+     * Header encoding
+     *
+     * @var string
+     */
+    protected $encoding = 'ASCII';
+
+    public function setEncoding($encoding)
+    {
+        $this->encoding = 'ASCII';
+        return $this;
+    }
+}

--- a/src/Header/HeaderLoader.php
+++ b/src/Header/HeaderLoader.php
@@ -20,6 +20,9 @@ class HeaderLoader extends PluginClassLoader
     protected $plugins = [
         'bcc'                       => 'Zend\Mail\Header\Bcc',
         'cc'                        => 'Zend\Mail\Header\Cc',
+        'contentdisposition'        => 'Zend\Mail\Header\ContentDisposition',
+        'content_disposition'       => 'Zend\Mail\Header\ContentDisposition',
+        'content-disposition'       => 'Zend\Mail\Header\ContentDisposition',
         'contenttype'               => 'Zend\Mail\Header\ContentType',
         'content_type'              => 'Zend\Mail\Header\ContentType',
         'content-type'              => 'Zend\Mail\Header\ContentType',


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.

Always use ASCII for the `content-disposition` header. When using UTF-8 encoding, this results in a header being set as `Content-Disposition: =?utf-8?Q?inline?=` which is not interpreted properly by Thunderbird nor Microsoft Exchange / Outlook. This pull request forces encoding for this header to always be ASCII, so that the header reads `Content-Disposition: inline` and is correctly interpreted by email clients.

Fixes: https://github.com/magento/magento2/issues/25076